### PR TITLE
Remove some hard coded paths in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _state*
 .idea*
 .DS_Store
+bin/*
 bootstrap/bootstrap.go

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Use at your own risk and if you're as excited about it as we are, maybe you want
 
 ## Installing
 
-```
-$ go get github.com/kris-nova/kubicorn
-```
+run `go get github.com/kris-nova/kubicorn` or read the [Install Guide](docs/INSTALL.md).
+
 ## How is Kubicorn different?
 
 1) We use kubeadm to bootstrap our clusters
@@ -75,3 +74,4 @@ Take a snap, save a snap, deploy a snap.
 | ---------------------------| ----------------------------------------------------------- |:----------------------------------------------------------------------:|
 | **Walkthrough**            | A walkthrough guide on install Kubernetes 1.7.0 in AWS      | [walkthrough](docs/aws/walkthrough.md)                                 |
 | **Video**                  | A step by step video of using Kubicorn in AWS               | [video](https://www.useloom.com/share/a0afd5034e654b0b8d6785a5fa8ec754)|
+| **Install**                | Install guide for Kubicorn CLI                              | [install](docs/INSTALL.md)                                             |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,36 @@
+# Installing Kubicorn
+
+## Quickstart
+
+If you have a working Golang environment the fastest way to install and run
+kubicorn is:
+
+```bash
+$ go get github.com/kris-nova/kubicorn
+$ ls $GOPATH/bin/kubicorn
+/home/pczarkowski/development/go/bin/kubicorn
+```
+
+## Not so Quickstart
+
+If you clone down this repo you can also build it with a local GO environment by running:
+
+```bash
+$ make all
+$ ls $GOPATH/bin/kubicorn
+/home/pczarkowski/development/go/bin/kubicorn
+```
+
+Otherwise you can try to build it in a Docker container:
+
+> Note: we need to take ownership back from root (thanks Docker!) and rename
+  it when we install it to $GOPATH/bin
+
+
+```bash
+$ make build-linux-amd64
+$ sudo chown $USER:$USER bin/*
+$ install --mode 0755 bin/linux-amd64 $GOPATH/bin/kubicorn
+$ ls $GOPATH/bin/kubicorn
+/home/pczarkowski/development/go/bin/kubicorn
+```


### PR DESCRIPTION
* There were a few hardcoded paths that seemed unecessary as they can be referred to from current directory
* Attempt to deal with go-bindata not being present ( took me a while to figure out what was going on )
* Make `bin/` dir before building with docker so at least its owned by non-root even if binaries are.
* Add bin/ to gitignore
* Update readme with install options
