### PR TITLE
Support MFA and roles when doing auth

### DIFF
--- a/cloud/amazon/awsSdkGo/sdk.go
+++ b/cloud/amazon/awsSdkGo/sdk.go
@@ -2,6 +2,7 @@ package awsSdkGo
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -16,7 +17,12 @@ type Sdk struct {
 
 func NewSdk(region string) (*Sdk, error) {
 	sdk := &Sdk{}
-	session, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	session, err := session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{Region: aws.String(region)},
+		// Support MFA when authing using assumed roles.
+		SharedConfigState:       session.SharedConfigEnable,
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We set up our AWS so that the default account has little/zero permissions and we do everything through roles across accounts.  We also require MFA in a lot of places.  This magic incantation when creating the session makes the SDK act more like the aws command line tools.  

You can do something like `export AWS_DEFAULT_PROFILE=dev-joe` to set the profile to the one that you want to use and now kubicorn will pick it up.