### PR TITLE
add support for travis.ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.8.3
+
+script:
+  - make test
+  - make compile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/kris-nova/klone)](https://goreportcard.com/report/github.com/nivenly/kamp)  [![GoDoc Widget]][GoDoc]
-
+[![Build Status](https://travis-ci.org/kris-nova/kubicorn.svg?branch=master)](https://travis-ci.org/kris-nova/kubicorn)
 [GoDoc]: https://godoc.org/k8s.io/kops
 [GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
 


### PR DESCRIPTION
This should resolve issue #68 by adding travis.ci support.  It's free for opensource
so should be easily enabled by connecting travis.ci with the repo by somebody who has access ( @kris-nova ) to connect via oauth and authorize travis to the repo.

I figured it would be worth doing both `make test` and `make compile` to ensure both steps work in a fairly blank go environment on PRs/Merges.