### PR TITLE
makefile: silent makefile by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifndef VERBOSE
+	MAKEFLAGS += --silent
+endif
+
 PKGS=$(shell go list ./... | grep -v /vendor)
 SHELL_IMAGE=golang:1.8.3
 GIT_SHA=$(shell git rev-parse --verify HEAD)

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -245,12 +245,12 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"bootstrap/README.md": bootstrapReadmeMd,
-	"bootstrap/amazon_k8s_1.7.0_ubuntu_16.04_master.sh": bootstrapAmazon_k8s_170_ubuntu_1604_masterSh,
-	"bootstrap/amazon_k8s_1.7.0_ubuntu_16.04_node.sh": bootstrapAmazon_k8s_170_ubuntu_1604_nodeSh,
+	"bootstrap/README.md":                                     bootstrapReadmeMd,
+	"bootstrap/amazon_k8s_1.7.0_ubuntu_16.04_master.sh":       bootstrapAmazon_k8s_170_ubuntu_1604_masterSh,
+	"bootstrap/amazon_k8s_1.7.0_ubuntu_16.04_node.sh":         bootstrapAmazon_k8s_170_ubuntu_1604_nodeSh,
 	"bootstrap/digitalocean_k8s_1.7.0_ubuntu_16.04_master.sh": bootstrapDigitalocean_k8s_170_ubuntu_1604_masterSh,
-	"bootstrap/digitalocean_k8s_1.7.0_ubuntu_16.04_node.sh": bootstrapDigitalocean_k8s_170_ubuntu_1604_nodeSh,
-	"bootstrap/inject.go": bootstrapInjectGo,
+	"bootstrap/digitalocean_k8s_1.7.0_ubuntu_16.04_node.sh":   bootstrapDigitalocean_k8s_170_ubuntu_1604_nodeSh,
+	"bootstrap/inject.go":                                     bootstrapInjectGo,
 }
 
 // AssetDir returns the file names below a certain
@@ -292,13 +292,14 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"bootstrap": &bintree{nil, map[string]*bintree{
-		"README.md": &bintree{bootstrapReadmeMd, map[string]*bintree{}},
-		"amazon_k8s_1.7.0_ubuntu_16.04_master.sh": &bintree{bootstrapAmazon_k8s_170_ubuntu_1604_masterSh, map[string]*bintree{}},
-		"amazon_k8s_1.7.0_ubuntu_16.04_node.sh": &bintree{bootstrapAmazon_k8s_170_ubuntu_1604_nodeSh, map[string]*bintree{}},
+		"README.md":                                     &bintree{bootstrapReadmeMd, map[string]*bintree{}},
+		"amazon_k8s_1.7.0_ubuntu_16.04_master.sh":       &bintree{bootstrapAmazon_k8s_170_ubuntu_1604_masterSh, map[string]*bintree{}},
+		"amazon_k8s_1.7.0_ubuntu_16.04_node.sh":         &bintree{bootstrapAmazon_k8s_170_ubuntu_1604_nodeSh, map[string]*bintree{}},
 		"digitalocean_k8s_1.7.0_ubuntu_16.04_master.sh": &bintree{bootstrapDigitalocean_k8s_170_ubuntu_1604_masterSh, map[string]*bintree{}},
-		"digitalocean_k8s_1.7.0_ubuntu_16.04_node.sh": &bintree{bootstrapDigitalocean_k8s_170_ubuntu_1604_nodeSh, map[string]*bintree{}},
+		"digitalocean_k8s_1.7.0_ubuntu_16.04_node.sh":   &bintree{bootstrapDigitalocean_k8s_170_ubuntu_1604_nodeSh, map[string]*bintree{}},
 		"inject.go": &bintree{bootstrapInjectGo, map[string]*bintree{}},
 	}},
 }}
@@ -349,4 +350,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/cutil/kubeconfig/kubeconfig.go
+++ b/cutil/kubeconfig/kubeconfig.go
@@ -7,11 +7,11 @@ import (
 	"github.com/kris-nova/kubicorn/logger"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
-	"os"
 	"net"
+	"os"
 	"strings"
 	"time"
 )
@@ -35,8 +35,8 @@ func GetConfig(existing *cluster.Cluster) error {
 	//fmt.Println(remotePath)
 	//fmt.Println(localPath)
 
-  agent := sshAgent()
-  if agent != nil {
+	agent := sshAgent()
+	if agent != nil {
 		auths := []ssh.AuthMethod{
 			agent,
 		}


### PR DESCRIPTION
Fixes #111 
Nobody is complaining on the issue so I gave it a try. I tested this myself and it's working.

I made it like this so if somebody is interested in the output, it can use `VERBOSE` variable to see what's happening (e.g. `VERBOSE=1 make gofmt`). It's not needed, but this way could satisfy everybody. If you have something against it I'll remove it. =)

Example:
```
18:08 in github.com/kris-nova/kubicorn on  silent-makefile [!] via 🐹 v1.9 on 🐳 v17.06.0-ce took 2s 
➜ make gofmt

18:08 in github.com/kris-nova/kubicorn on  silent-makefile [!] via 🐹 v1.9 on 🐳 v17.06.0-ce 
➜ VERBOSE=1 make gofmt
gofmt -w ./apis
gofmt -w ./bootstrap
gofmt -w ./cloud
gofmt -w ./cmd
gofmt -w ./cutil
gofmt -w ./docs
gofmt -w ./examples
gofmt -w ./logger
gofmt -w ./namer
gofmt -w ./profiles
gofmt -w ./state

```