### PR TITLE
readme: fix go reportcard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/kris-nova/kubicorn.svg?branch=master)](https://travis-ci.org/kris-nova/kubicorn) [![Go Report Card](https://goreportcard.com/badge/github.com/kris-nova/klone)](https://goreportcard.com/report/github.com/nivenly/kamp)
+[![Build Status](https://travis-ci.org/kris-nova/kubicorn.svg?branch=master)](https://travis-ci.org/kris-nova/kubicorn) [![Go Report Card](https://goreportcard.com/badge/github.com/kris-nova/kubicorn)](https://goreportcard.com/report/github.com/kris-nova/kubicorn)
 # kubicorn
 
 Create, manage, snapshot, and scale Kubernetes infrastructure in the public cloud.


### PR DESCRIPTION
This PR fixes link for the Go ReportCard in the Readme file. Currently Go Report Card is showing badge for kris-nova/klone and linking to nivenly/kamp