### PR TITLE
makefile: check-header implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ test:
 vet:
 	@go vet $(PKGS)
 
+check-header:
+	./scripts/check-header.sh
+
 .PHONY: apimachinery
 apimachinery:
 	go get k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen

--- a/scripts/check-header.sh
+++ b/scripts/check-header.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+read -r -d '' EXPECTED <<EOF
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+EOF
+
+FILES=$(find . -name "*.go" -not -path "./vendor/*")
+
+for FILE in $FILES; do
+        HEADER=$(head -n 13 $FILE)
+        if [ "$HEADER" != "$EXPECTED" ]; then
+                echo "incorrect license header: $FILE"                
+        fi
+done


### PR DESCRIPTION
Partially addresses #88 

This implements `check-header` command for Makefile. Running `make check-header` returns the following:
```
incorrect license header: ./bootstrap/bootstrap.go
incorrect license header: ./bootstrap/inject.go
incorrect license header: ./cutil/hang/ratio.go
incorrect license header: ./cutil/kubeadm/token.go
incorrect license header: ./cutil/initapi/init.go
incorrect license header: ./cutil/initapi/ssh.go
incorrect license header: ./cutil/initapi/validate.go
...
```

It uses external script, located at the `./scripts` directory, but I think it's easiest and best? way to do this.
If you have anything against this way, I'll revisit this PR :+1: 