### PR TITLE
Tweak make authorsfile script and remove duplicate authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,10 +3,8 @@ Eric Hole <eric.hole@gmail.com>
 Igor Vuk <parcijala@gmail.com>
 Joe Beda <joe.github@bedafamily.com>
 Joshua Carp <jm.carp@gmail.com>
-@Kris__Nova <kris@nivenly.com>
 Kris Nova <kris@nivenly.com>
 Marko Mudrinić <mudrinic.mare@gmail.com>
 Michael Hausenblas <michael.hausenblas@gmail.com>
 Paul Czarkowski <username.taken@gmail.com>
-Ted Wood <ted@mailchimp.com>
 Ted Wood <ted@xy0.org>

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ bindata:
 build: authors clean build-linux-amd64 build-darwin-amd64 build-freebsd-amd64 build-windows-amd64
 
 authorsfile:
-	git log --all --format='%aN <%cE>' | sort -u | grep -v "noreply@github.com" > AUTHORS
+	git log --all --format='%aN <%cE>' | sort -u | egrep -v "noreply|mailchimp|@Kris" > AUTHORS
 
 clean:
 	rm -rf bin/*


### PR DESCRIPTION
👋  I'm new here! I saw a tiny thing I may be able to help with. Feel free to ignore :) 

When generating the AUTHORS file the Makefile relies on a git log that may or may not be representative of the valuable data. It's very easy to omit configuration of the git config which easily makes for duplicate authors.

This change tweaks the output of the sorted git log, pipes the values into egrep that relies on an inverse filter that's easily extended. This change should not be seen as a long-term solution as the regex could quickly grow out of hand.