### PR TITLE
scripts: make check-header return exit code

### DIFF
--- a/scripts/check-header.sh
+++ b/scripts/check-header.sh
@@ -30,11 +30,15 @@ read -r -d '' EXPECTED <<EOF
 // limitations under the License.
 EOF
 
+STATUS=0
 FILES=$(find . -name "*.go" -not -path "./vendor/*")
 
 for FILE in $FILES; do
         HEADER=$(head -n 13 $FILE)
         if [ "$HEADER" != "$EXPECTED" ]; then
-                echo "incorrect license header: $FILE"                
+                echo "incorrect license header: $FILE"
+		STATUS=1
         fi
 done
+
+exit $STATUS


### PR DESCRIPTION
We've added `make check-header` to CI so license headers are tested on every PR/commit.

The problem is that in current implementation it doesn't return error code so it will pass every time.
I've changed this to return code 1 if incorrect header is found. In that case CI will fail.

