### PR TITLE
completion: generation of bash and zsh completion codes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -167,7 +167,7 @@
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "715f41bd7a70b5111f898b71ab484da52ee6266d"
+  revision = "b26b538f693051ac6518e65672de3144ce3fbedc"
 
 [[projects]]
   branch = "master"

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,270 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const license = `# Copyright © 2017 The Kubicorn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+`
+
+// completionCmd represents the completion command
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Generate completion code for bash and zsh shells.",
+	Long: `completion is used to output completion code for bash and zsh shells.
+
+Before using completion features, you have to source completion code
+from your .profile. This is done by adding following line to one of above files:
+	source <(kubicorn completion SHELL)
+Valid arguments for SHELL are: "bash" and "zsh".
+Notes:
+1) zsh completions requires zsh 5.2 or newer.
+	
+2) macOS users have to install bash-completion framework to utilize
+completion features. This can be done using homebrew:
+	brew install bash-completion
+Once installed, you must load bash_completion by adding following
+line to your .profile or .bashrc/.zshrc:
+	source $(brew --prefix)/etc/bash_completion`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if fabulous {
+			cmd.SetOutput(fabulousWriter)
+		}
+		if os.Getenv("KUBICORN_TRUECOLOR") != "" {
+			cmd.SetOutput(fabulousWriter)
+		}
+
+		if len(args) != 1 {
+			return fmt.Errorf("shell argument is not specified")
+		}
+		shell := args[0]
+
+		if shell == "bash" {
+			return RunBashGeneration()
+		} else if shell == "zsh" {
+			return RunZshGeneration()
+		} else {
+			return fmt.Errorf("invalid shell argument")
+		}		
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(completionCmd)
+}
+
+func RunBashGeneration() error {
+	var buf bytes.Buffer
+
+	_, err := buf.Write([]byte(license))
+	if err != nil {
+		return fmt.Errorf("error while generating bash completion: %v", err)
+	}
+
+	err = RootCmd.GenBashCompletion(&buf)
+	if err != nil {
+		return fmt.Errorf("error generating bash completion: %v", err)
+	}
+
+	fmt.Printf("%s", buf.String())
+
+	return nil
+}
+
+func RunZshGeneration() error {
+	var buf bytes.Buffer
+
+	// zshInit converts appropriate bash to zsh code.
+	zshInit := `
+__kubicorn_bash_source() {
+	alias shopt=':'
+	alias _expand=_bash_expand
+	alias _complete=_bash_comp
+	emulate -L sh
+	setopt kshglob noshglob braceexpand
+	source "$@"
+}
+__kubicorn_type() {
+	# -t is not supported by zsh
+	if [ "$1" == "-t" ]; then
+		shift
+		# fake Bash 4 to disable "complete -o nospace". Instead
+		# "compopt +-o nospace" is used in the code to toggle trailing
+		# spaces. We don't support that, but leave trailing spaces on
+		# all the time
+		if [ "$1" = "__kubicorn_compopt" ]; then
+			echo builtin
+			return 0
+		fi
+	fi
+	type "$@"
+}
+__kubicorn_compgen() {
+	local completions w
+	completions=( $(compgen "$@") ) || return $?
+	# filter by given word as prefix
+	while [[ "$1" = -* && "$1" != -- ]]; do
+		shift
+		shift
+	done
+	if [[ "$1" == -- ]]; then
+		shift
+	fi
+	for w in "${completions[@]}"; do
+		if [[ "${w}" = "$1"* ]]; then
+			echo "${w}"
+		fi
+	done
+}
+__kubicorn_compopt() {
+	true # don't do anything. Not supported by bashcompinit in zsh
+}
+__kubicorn_declare() {
+	if [ "$1" == "-F" ]; then
+		whence -w "$@"
+	else
+		builtin declare "$@"
+	fi
+}
+__kubicorn_ltrim_colon_completions()
+{
+	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
+		# Remove colon-word prefix from COMPREPLY items
+		local colon_word=${1%${1##*:}}
+		local i=${#COMPREPLY[*]}
+		while [[ $((--i)) -ge 0 ]]; do
+			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
+		done
+	fi
+}
+__kubicorn_get_comp_words_by_ref() {
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
+	words=("${COMP_WORDS[@]}")
+	cword=("${COMP_CWORD[@]}")
+}
+__kubicorn_filedir() {
+	local RET OLD_IFS w qw
+	__debug "_filedir $@ cur=$cur"
+	if [[ "$1" = \~* ]]; then
+		# somehow does not work. Maybe, zsh does not call this at all
+		eval echo "$1"
+		return 0
+	fi
+	OLD_IFS="$IFS"
+	IFS=$'\n'
+	if [ "$1" = "-d" ]; then
+		shift
+		RET=( $(compgen -d) )
+	else
+		RET=( $(compgen -f) )
+	fi
+	IFS="$OLD_IFS"
+	IFS="," __debug "RET=${RET[@]} len=${#RET[@]}"
+	for w in ${RET[@]}; do
+		if [[ ! "${w}" = "${cur}"* ]]; then
+			continue
+		fi
+		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
+			qw="$(__kubicorn_quote "${w}")"
+			if [ -d "${w}" ]; then
+				COMPREPLY+=("${qw}/")
+			else
+				COMPREPLY+=("${qw}")
+			fi
+		fi
+	done
+}
+__kubicorn_quote() {
+    if [[ $1 == \'* || $1 == \"* ]]; then
+        # Leave out first character
+        printf %q "${1:1}"
+    else
+    	printf %q "$1"
+    fi
+}
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+# use word boundary patterns for BSD or GNU sed
+LWORD='[[:<:]]'
+RWORD='[[:>:]]'
+if sed --help 2>&1 | grep -q GNU; then
+	LWORD='\<'
+	RWORD='\>'
+fi
+__kubicorn_convert_bash_to_zsh() {
+	sed \
+	-e 's/declare -F/whence -w/' \
+	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
+	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
+	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
+	-e "s/${LWORD}_filedir${RWORD}/__kubicorn_filedir/g" \
+	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__kubicorn_get_comp_words_by_ref/g" \
+	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__kubicorn_ltrim_colon_completions/g" \
+	-e "s/${LWORD}compgen${RWORD}/__kubicorn_compgen/g" \
+	-e "s/${LWORD}compopt${RWORD}/__kubicorn_compopt/g" \
+	-e "s/${LWORD}declare${RWORD}/__kubicorn_declare/g" \
+	-e "s/\\\$(type${RWORD}/\$(__kubicorn_type/g" \
+	<<'BASH_COMPLETION_EOF'
+`
+
+	// zshFinalize is code going to the end of completion file.
+	// It that calls conversion bash to zsh.
+	zshFinalize := `
+BASH_COMPLETION_EOF
+}
+__kubicorn_bash_source <(__kubicorn_convert_bash_to_zsh)
+	`
+
+	_, err := buf.Write([]byte(license))
+	if err != nil {
+		return fmt.Errorf("error while generating zsh completion: %v", err)
+	}
+
+	_, err = buf.Write([]byte(zshInit))
+
+	err = RootCmd.GenBashCompletion(&buf)
+	if err != nil {
+		return fmt.Errorf("error wheil generating zsh completion: %v", err)
+	}
+
+	_, err = buf.Write([]byte(zshFinalize))
+	if err != nil {
+		return fmt.Errorf("error while generating zsh completion: %v", err)
+	}
+
+	fmt.Printf("%s", buf.String())
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,8 @@ var cfgFile string
 // fabulous enables rainbow colored output
 var fabulous bool
 
+var fabulousWriter = &lol.Writer{Output: os.Stdout, ColorMode: lol.ColorMode256}
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "kubicorn",
@@ -37,10 +39,10 @@ var RootCmd = &cobra.Command{
 `, Unicorn),
 	Run: func(cmd *cobra.Command, args []string) {
 		if fabulous {
-			cmd.SetOutput(&lol.Writer{Output: os.Stdout, ColorMode: lol.ColorMode256})
+			cmd.SetOutput(fabulousWriter)
 		}
 		if os.Getenv("KUBICORN_TRUECOLOR") != "" {
-			cmd.SetOutput(&lol.Writer{Output: os.Stdout, ColorMode: lol.ColorModeTrueColor})
+			cmd.SetOutput(fabulousWriter)
 		}
 		cmd.Help()
 	},	

--- a/vendor/github.com/spf13/cobra/.travis.yml
+++ b/vendor/github.com/spf13/cobra/.travis.yml
@@ -2,8 +2,8 @@ language: go
 
 matrix:
   include:
-    - go: 1.7.5
-    - go: 1.8.1
+    - go: 1.7.6
+    - go: 1.8.3
     - go: tip
   allow_failures:
     - go: tip

--- a/vendor/github.com/spf13/cobra/README.md
+++ b/vendor/github.com/spf13/cobra/README.md
@@ -485,6 +485,36 @@ when the `--author` flag is not provided by user.
 
 More in [viper documentation](https://github.com/spf13/viper#working-with-flags).
 
+## Positional and Custom Arguments
+
+Validation of positional arguments can be specified using the `Args` field.
+
+The follow validators are built in:
+
+- `NoArgs` - the command will report an error if there are any positional args.
+- `ArbitraryArgs` - the command will accept any args.
+- `OnlyValidArgs` - the command will report an error if there are any positional args that are not in the ValidArgs list.
+- `MinimumNArgs(int)` - the command will report an error if there are not at least N positional args.
+- `MaximumNArgs(int)` - the command will report an error if there are more than N positional args.
+- `ExactArgs(int)` - the command will report an error if there are not exactly N positional args.
+- `RangeArgs(min, max)` - the command will report an error if the number of args is not between the minimum and maximum number of expected args.
+
+A custom validator can be provided like this:
+
+```go
+
+Args: func validColorArgs(cmd *cobra.Command, args []string) error {
+  if err := cli.RequiresMinArgs(1)(cmd, args); err != nil {
+    return err
+  }
+  if myapp.IsValidColor(args[0]) {
+     return nil
+  }
+  return fmt.Errorf("Invalid color specified: %s", args[0])
+}
+
+```
+
 ## Example
 
 In the example below, we have defined three commands. Two are at the top level

--- a/vendor/github.com/spf13/cobra/args.go
+++ b/vendor/github.com/spf13/cobra/args.go
@@ -1,0 +1,98 @@
+package cobra
+
+import (
+	"fmt"
+)
+
+type PositionalArgs func(cmd *Command, args []string) error
+
+// Legacy arg validation has the following behaviour:
+// - root commands with no subcommands can take arbitrary arguments
+// - root commands with subcommands will do subcommand validity checking
+// - subcommands will always accept arbitrary arguments
+func legacyArgs(cmd *Command, args []string) error {
+	// no subcommand, always take args
+	if !cmd.HasSubCommands() {
+		return nil
+	}
+
+	// root command with subcommands, do subcommand checking
+	if !cmd.HasParent() && len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q%s", args[0], cmd.CommandPath(), cmd.findSuggestions(args[0]))
+	}
+	return nil
+}
+
+// NoArgs returns an error if any args are included
+func NoArgs(cmd *Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+	}
+	return nil
+}
+
+// OnlyValidArgs returns an error if any args are not in the list of ValidArgs
+func OnlyValidArgs(cmd *Command, args []string) error {
+	if len(cmd.ValidArgs) > 0 {
+		for _, v := range args {
+			if !stringInSlice(v, cmd.ValidArgs) {
+				return fmt.Errorf("invalid argument %q for %q%s", v, cmd.CommandPath(), cmd.findSuggestions(args[0]))
+			}
+		}
+	}
+	return nil
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ArbitraryArgs never returns an error
+func ArbitraryArgs(cmd *Command, args []string) error {
+	return nil
+}
+
+// MinimumNArgs returns an error if there is not at least N args
+func MinimumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) < n {
+			return fmt.Errorf("requires at least %d arg(s), only received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// MaximumNArgs returns an error if there are more than N args
+func MaximumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) > n {
+			return fmt.Errorf("accepts at most %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// ExactArgs returns an error if there are not exactly n args
+func ExactArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) != n {
+			return fmt.Errorf("accepts %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// RangeArgs returns an error if the number of args is not within the expected range
+func RangeArgs(min int, max int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) < min || len(args) > max {
+			return fmt.Errorf("accepts between %d and %d arg(s), received %d", min, max, len(args))
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/spf13/cobra/bash_completions_test.go
+++ b/vendor/github.com/spf13/cobra/bash_completions_test.go
@@ -117,6 +117,8 @@ func TestBashCompletions(t *testing.T) {
 	// check for filename extension flags
 	check(t, str, `flags_completion+=("_filedir")`)
 	// check for filename extension flags
+	check(t, str, `must_have_one_noun+=("three")`)
+	// check for filename extention flags
 	check(t, str, `flags_completion+=("__handle_filename_extension_flag json|yaml|yml")`)
 	// check for custom flags
 	check(t, str, `flags_completion+=("__complete_custom")`)

--- a/vendor/github.com/spf13/cobra/cobra/cmd/add.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/add.go
@@ -121,7 +121,7 @@ func validateCmdName(source string) string {
 
 func createCmdFile(license License, path, cmdName string) {
 	template := `{{comment .copyright}}
-{{comment .license}}
+{{if .license}}{{comment .license}}{{end}}
 
 package {{.cmdPackage}}
 

--- a/vendor/github.com/spf13/cobra/cobra/cmd/add_test.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/add_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 // TestGoldenAddCmd initializes the project "github.com/spf13/testproject"
@@ -16,10 +18,17 @@ import (
 func TestGoldenAddCmd(t *testing.T) {
 	projectName := "github.com/spf13/testproject"
 	project := NewProject(projectName)
-
-	// Initialize the project at first.
-	initializeProject(project)
 	defer os.RemoveAll(project.AbsPath())
+
+	viper.Set("author", "NAME HERE <EMAIL ADDRESS>")
+	viper.Set("license", "apache")
+	viper.Set("year", 2017)
+	defer viper.Set("author", nil)
+	defer viper.Set("license", nil)
+	defer viper.Set("year", nil)
+
+	// Initialize the project first.
+	initializeProject(project)
 
 	// Then add the "test" command.
 	cmdName := "test"
@@ -48,7 +57,7 @@ func TestGoldenAddCmd(t *testing.T) {
 		goldenPath := filepath.Join("testdata", filepath.Base(path)+".golden")
 
 		switch relPath {
-		// Know directories.
+		// Known directories.
 		case ".":
 			return nil
 		// Known files.

--- a/vendor/github.com/spf13/cobra/cobra/cmd/golden_test.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/golden_test.go
@@ -39,11 +39,11 @@ func compareFiles(pathA, pathB string) error {
 			// Don't execute diff if it can't be found.
 			return nil
 		}
-		diffCmd := exec.Command(diffPath, pathA, pathB)
+		diffCmd := exec.Command(diffPath, "-u", pathA, pathB)
 		diffCmd.Stdout = output
 		diffCmd.Stderr = output
 
-		output.WriteString("$ diff " + pathA + " " + pathB + "\n")
+		output.WriteString("$ diff -u " + pathA + " " + pathB + "\n")
 		if err := diffCmd.Run(); err != nil {
 			output.WriteString("\n" + err.Error())
 		}

--- a/vendor/github.com/spf13/cobra/cobra/cmd/init_test.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/init_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 // TestGoldenInitCmd initializes the project "github.com/spf13/testproject"
@@ -16,6 +18,13 @@ func TestGoldenInitCmd(t *testing.T) {
 	projectName := "github.com/spf13/testproject"
 	project := NewProject(projectName)
 	defer os.RemoveAll(project.AbsPath())
+
+	viper.Set("author", "NAME HERE <EMAIL ADDRESS>")
+	viper.Set("license", "apache")
+	viper.Set("year", 2017)
+	defer viper.Set("author", nil)
+	defer viper.Set("license", nil)
+	defer viper.Set("year", nil)
 
 	os.Args = []string{"cobra", "init", projectName}
 	if err := rootCmd.Execute(); err != nil {
@@ -44,7 +53,7 @@ func TestGoldenInitCmd(t *testing.T) {
 		goldenPath := filepath.Join("testdata", filepath.Base(path)+".golden")
 
 		switch relPath {
-		// Know directories.
+		// Known directories.
 		case ".", "cmd":
 			return nil
 		// Known files.

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_agpl.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_agpl.go
@@ -4,8 +4,7 @@ func initAgpl() {
 	Licenses["agpl"] = License{
 		Name:            "GNU Affero General Public License",
 		PossibleMatches: []string{"agpl", "affero gpl", "gnu agpl"},
-		Header: `{{.copyright}}
-
+		Header: `
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_apache_2.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_apache_2.go
@@ -19,7 +19,8 @@ func initApache2() {
 	Licenses["apache"] = License{
 		Name:            "Apache 2.0",
 		PossibleMatches: []string{"apache", "apache20", "apache 2.0", "apache2.0", "apache-2.0"},
-		Header: `Licensed under the Apache License, Version 2.0 (the "License");
+		Header: `
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_2.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_2.go
@@ -20,8 +20,7 @@ func initBsdClause2() {
 		Name: "Simplified BSD License",
 		PossibleMatches: []string{"freebsd", "simpbsd", "simple bsd", "2-clause bsd",
 			"2 clause bsd", "simplified bsd license"},
-		Header: `
-All rights reserved.
+		Header: `All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_3.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_bsd_clause_3.go
@@ -19,8 +19,7 @@ func initBsdClause3() {
 	Licenses["bsd"] = License{
 		Name:            "NewBSD",
 		PossibleMatches: []string{"bsd", "newbsd", "3 clause bsd", "3-clause bsd"},
-		Header: `
-All rights reserved.
+		Header: `All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_2.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_2.go
@@ -19,20 +19,19 @@ func initGpl2() {
 	Licenses["gpl2"] = License{
 		Name:            "GNU General Public License 2.0",
 		PossibleMatches: []string{"gpl2", "gnu gpl2", "gplv2"},
-		Header: `{{.copyright}}
+		Header: `
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>.`,
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.`,
 		Text: `                    GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_3.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_gpl_3.go
@@ -19,8 +19,7 @@ func initGpl3() {
 	Licenses["gpl3"] = License{
 		Name:            "GNU General Public License 3.0",
 		PossibleMatches: []string{"gpl3", "gplv3", "gpl", "gnu gpl3", "gnu gpl"},
-		Header: `{{.copyright}}
-
+		Header: `
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_lgpl.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_lgpl.go
@@ -4,8 +4,7 @@ func initLgpl() {
 	Licenses["lgpl"] = License{
 		Name:            "GNU Lesser General Public License",
 		PossibleMatches: []string{"lgpl", "lesser gpl", "gnu lgpl"},
-		Header: `{{.copyright}}
-
+		Header: `
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or

--- a/vendor/github.com/spf13/cobra/cobra/cmd/license_mit.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/license_mit.go
@@ -17,7 +17,7 @@ package cmd
 
 func initMit() {
 	Licenses["mit"] = License{
-		Name:            "Mit",
+		Name:            "MIT License",
 		PossibleMatches: []string{"mit"},
 		Header: `
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/vendor/github.com/spf13/cobra/cobra/cmd/licenses.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/licenses.go
@@ -77,7 +77,11 @@ func getLicense() License {
 
 func copyrightLine() string {
 	author := viper.GetString("author")
-	year := time.Now().Format("2006")
+
+	year := viper.GetString("year") // For tests.
+	if year == "" {
+		year = time.Now().Format("2006")
+	}
 
 	return "Copyright © " + year + " " + author
 }

--- a/vendor/github.com/spf13/cobra/cobra/cmd/root.go
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/root.go
@@ -40,7 +40,7 @@ func Execute() {
 }
 
 func init() {
-	initViper()
+	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
 	rootCmd.PersistentFlags().StringP("author", "a", "YOUR NAME", "author name for copyright attribution")
@@ -55,7 +55,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 }
 
-func initViper() {
+func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)

--- a/vendor/github.com/spf13/cobra/cobra/cmd/testdata/main.go.golden
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/testdata/main.go.golden
@@ -1,4 +1,5 @@
 // Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/vendor/github.com/spf13/cobra/cobra/cmd/testdata/root.go.golden
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/testdata/root.go.golden
@@ -1,4 +1,5 @@
 // Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/vendor/github.com/spf13/cobra/cobra/cmd/testdata/test.go.golden
+++ b/vendor/github.com/spf13/cobra/cobra/cmd/testdata/test.go.golden
@@ -1,4 +1,5 @@
 // Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/vendor/github.com/spf13/cobra/zsh_completions.go
+++ b/vendor/github.com/spf13/cobra/zsh_completions.go
@@ -1,0 +1,114 @@
+package cobra
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// GenZshCompletion generates a zsh completion file and writes to the passed writer.
+func (cmd *Command) GenZshCompletion(w io.Writer) error {
+	buf := new(bytes.Buffer)
+
+	writeHeader(buf, cmd)
+	maxDepth := maxDepth(cmd)
+	writeLevelMapping(buf, maxDepth)
+	writeLevelCases(buf, maxDepth, cmd)
+
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+func writeHeader(w io.Writer, cmd *Command) {
+	fmt.Fprintf(w, "#compdef %s\n\n", cmd.Name())
+}
+
+func maxDepth(c *Command) int {
+	if len(c.Commands()) == 0 {
+		return 0
+	}
+	maxDepthSub := 0
+	for _, s := range c.Commands() {
+		subDepth := maxDepth(s)
+		if subDepth > maxDepthSub {
+			maxDepthSub = subDepth
+		}
+	}
+	return 1 + maxDepthSub
+}
+
+func writeLevelMapping(w io.Writer, numLevels int) {
+	fmt.Fprintln(w, `_arguments \`)
+	for i := 1; i <= numLevels; i++ {
+		fmt.Fprintf(w, `  '%d: :->level%d' \`, i, i)
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintf(w, `  '%d: :%s'`, numLevels+1, "_files")
+	fmt.Fprintln(w)
+}
+
+func writeLevelCases(w io.Writer, maxDepth int, root *Command) {
+	fmt.Fprintln(w, "case $state in")
+	defer fmt.Fprintln(w, "esac")
+
+	for i := 1; i <= maxDepth; i++ {
+		fmt.Fprintf(w, "  level%d)\n", i)
+		writeLevel(w, root, i)
+		fmt.Fprintln(w, "  ;;")
+	}
+	fmt.Fprintln(w, "  *)")
+	fmt.Fprintln(w, "    _arguments '*: :_files'")
+	fmt.Fprintln(w, "  ;;")
+}
+
+func writeLevel(w io.Writer, root *Command, i int) {
+	fmt.Fprintf(w, "    case $words[%d] in\n", i)
+	defer fmt.Fprintln(w, "    esac")
+
+	commands := filterByLevel(root, i)
+	byParent := groupByParent(commands)
+
+	for p, c := range byParent {
+		names := names(c)
+		fmt.Fprintf(w, "      %s)\n", p)
+		fmt.Fprintf(w, "        _arguments '%d: :(%s)'\n", i, strings.Join(names, " "))
+		fmt.Fprintln(w, "      ;;")
+	}
+	fmt.Fprintln(w, "      *)")
+	fmt.Fprintln(w, "        _arguments '*: :_files'")
+	fmt.Fprintln(w, "      ;;")
+
+}
+
+func filterByLevel(c *Command, l int) []*Command {
+	cs := make([]*Command, 0)
+	if l == 0 {
+		cs = append(cs, c)
+		return cs
+	}
+	for _, s := range c.Commands() {
+		cs = append(cs, filterByLevel(s, l-1)...)
+	}
+	return cs
+}
+
+func groupByParent(commands []*Command) map[string][]*Command {
+	m := make(map[string][]*Command)
+	for _, c := range commands {
+		parent := c.Parent()
+		if parent == nil {
+			continue
+		}
+		m[parent.Name()] = append(m[parent.Name()], c)
+	}
+	return m
+}
+
+func names(commands []*Command) []string {
+	ns := make([]string, len(commands))
+	for i, c := range commands {
+		ns[i] = c.Name()
+	}
+	return ns
+}

--- a/vendor/github.com/spf13/cobra/zsh_completions_test.go
+++ b/vendor/github.com/spf13/cobra/zsh_completions_test.go
@@ -1,0 +1,88 @@
+package cobra
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestZshCompletion(t *testing.T) {
+	tcs := []struct {
+		name                string
+		root                *Command
+		expectedExpressions []string
+	}{
+		{
+			name:                "trivial",
+			root:                &Command{Use: "trivialapp"},
+			expectedExpressions: []string{"#compdef trivial"},
+		},
+		{
+			name: "linear",
+			root: func() *Command {
+				r := &Command{Use: "linear"}
+
+				sub1 := &Command{Use: "sub1"}
+				r.AddCommand(sub1)
+
+				sub2 := &Command{Use: "sub2"}
+				sub1.AddCommand(sub2)
+
+				sub3 := &Command{Use: "sub3"}
+				sub2.AddCommand(sub3)
+				return r
+			}(),
+			expectedExpressions: []string{"sub1", "sub2", "sub3"},
+		},
+		{
+			name: "flat",
+			root: func() *Command {
+				r := &Command{Use: "flat"}
+				r.AddCommand(&Command{Use: "c1"})
+				r.AddCommand(&Command{Use: "c2"})
+				return r
+			}(),
+			expectedExpressions: []string{"(c1 c2)"},
+		},
+		{
+			name: "tree",
+			root: func() *Command {
+				r := &Command{Use: "tree"}
+
+				sub1 := &Command{Use: "sub1"}
+				r.AddCommand(sub1)
+
+				sub11 := &Command{Use: "sub11"}
+				sub12 := &Command{Use: "sub12"}
+
+				sub1.AddCommand(sub11)
+				sub1.AddCommand(sub12)
+
+				sub2 := &Command{Use: "sub2"}
+				r.AddCommand(sub2)
+
+				sub21 := &Command{Use: "sub21"}
+				sub22 := &Command{Use: "sub22"}
+
+				sub2.AddCommand(sub21)
+				sub2.AddCommand(sub22)
+
+				return r
+			}(),
+			expectedExpressions: []string{"(sub11 sub12)", "(sub21 sub22)"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			tc.root.GenZshCompletion(buf)
+			completion := buf.String()
+			for _, expectedExpression := range tc.expectedExpressions {
+				if !strings.Contains(completion, expectedExpression) {
+					t.Errorf("expected completion to contain '%v' somewhere; got '%v'", expectedExpression, completion)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements completion code generation for bash and zsh shells.

For now, it only offers basic set of features - completion for commands and flags. Next coming up (let's merge this as it is?) is resources completion from `_state` and similar locations. 

Here is a short guide how to use this:
```
completion is used to output completion code for bash and zsh shells.

Before using completion features, you have to source completion code
from your .profile. This is done by adding following line to one of above files:
	source <(kubicorn completion SHELL)
Valid arguments for SHELL are: "bash" and "zsh".
Notes:
1) zsh completions requires zsh 5.2 or newer.
	
2) macOS users have to install bash-completion framework to utilize
completion features. This can be done using homebrew:
	brew install bash-completion
Once installed, you must load bash_completion by adding following
line to your .profile or .bashrc/.zshrc:
	source $(brew --prefix)/etc/bash_completion

```
It's available on `kubicorn completion -h`.

Currently, it uses Bash -> Zsh conversion. Native Zsh generation is still under progress and in current state doesn't work well. I tried updating cobra but that didn't work. At least, we ended up with latest version of cobra.

Partially addresses #128 
Mentions #26 