### PR TITLE
Added dependency on libncurses5-dev in documenation and Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,4 +2,5 @@ FROM golang:1.8
 
 WORKDIR /go/src/
 
+RUN apt-get update && apt-get install -y libncurses5-dev
 RUN go get github.com/kris-nova/kubicorn/cmd

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -21,6 +21,12 @@ If you have this you should be able to run the following command:
 $ go get github.com/kris-nova/kubicorn
 ```
 
+You will also need a the `libncurses5-dev` package.
+```bash
+$ apt-get install libncurses5-dev
+```
+
+
 ### Building
 Now you can run `make` from the src directory of kubicorn:
 


### PR DESCRIPTION
A update to [lolgopher](https://github.com/kris-nova/lolgopher) added a dependency on ` libncurses5-dev` so i added this to the documentation and to the docker build script. Credit to @xmudrii for finding this (https://github.com/kris-nova/lolgopher/issues/11).