### PR TITLE
digitalocean: allow usage of encrypted keys

### DIFF
--- a/cloud/digitalocean/resources/ssh.go
+++ b/cloud/digitalocean/resources/ssh.go
@@ -102,7 +102,6 @@ func (r *SSH) Apply(actual, expected cloud.Resource, applyCluster *cluster.Clust
 		Name:      expected.(*SSH).Name,
 		PublicKey: expected.(*SSH).PublicKeyData,
 	}
-	fmt.Println(expected.(*SSH).PublicKeyFingerprint)
 	key, _, err := Sdk.Client.Keys.Create(context.TODO(), request)
 	if err != nil {
 		keyGet, _, errGet := Sdk.Client.Keys.GetByFingerprint(context.TODO(), expected.(*SSH).PublicKeyFingerprint)

--- a/cloud/digitalocean/resources/ssh.go
+++ b/cloud/digitalocean/resources/ssh.go
@@ -102,9 +102,14 @@ func (r *SSH) Apply(actual, expected cloud.Resource, applyCluster *cluster.Clust
 		Name:      expected.(*SSH).Name,
 		PublicKey: expected.(*SSH).PublicKeyData,
 	}
+	fmt.Println(expected.(*SSH).PublicKeyFingerprint)
 	key, _, err := Sdk.Client.Keys.Create(context.TODO(), request)
 	if err != nil {
-		return nil, err
+		keyGet, _, errGet := Sdk.Client.Keys.GetByFingerprint(context.TODO(), expected.(*SSH).PublicKeyFingerprint)
+		if errGet != nil {
+			return nil, err
+		}
+		key = keyGet
 	}
 	logger.Info("Created SSH Key [%d]", key.ID)
 	id := strconv.Itoa(key.ID)

--- a/cutil/initapi/ssh.go
+++ b/cutil/initapi/ssh.go
@@ -15,9 +15,6 @@
 package initapi
 
 import (
-	"golang.org/x/crypto/ssh/agent"
-	"os"
-	"net"
 	"golang.org/x/crypto/ssh/terminal"
 	"github.com/kris-nova/klone/pkg/local"
 	"github.com/kris-nova/kubicorn/apis/cluster"
@@ -94,11 +91,4 @@ func GetSigner(pemBytes []byte) (ssh.Signer, error) {
 	} else {
 		return signerwithoutpassphrase, err
 	}
-}
-
-func sshAgent() ssh.AuthMethod {
-	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
-		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
-	}
-	return nil
 }

--- a/cutil/kubeconfig/kubeconfig.go
+++ b/cutil/kubeconfig/kubeconfig.go
@@ -148,6 +148,7 @@ func GetSigner(pemBytes []byte) (ssh.Signer, error) {
 		logger.Info(err.Error())
 		fmt.Print("SSH Key Passphrase [none]: ")
 		passPhrase, err := terminal.ReadPassword(0)
+		fmt.Println("")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #137 
Beside #137, allowed SSH key reusability!

Everything is supposed to work correctly now, tested locally. If you don't mind, give it a try just to be sure non-encrypted keys are working as indeed too