### PR TITLE
kubeconfig: create .kube dir if it doesn't exist

### DIFF
--- a/cutil/kubeconfig/kubeconfig.go
+++ b/cutil/kubeconfig/kubeconfig.go
@@ -36,12 +36,10 @@ func GetConfig(existing *cluster.Cluster) error {
 	privKeyPath := strings.Replace(pubKeyPath, ".pub", "", 1)
 	address := fmt.Sprintf("%s:%s", existing.KubernetesApi.Endpoint, "22")
 	localDir := fmt.Sprintf("%s/.kube", local.Home())
-	if _, err := os.Stat(localDir); os.IsNotExist(err) {	
-			if err := os.Mkdir(localDir, 0777); err != nil {
-				return err
-			}
+	localPath, err := getKubeConfigPath(localDir)
+	if err != nil {
+		return err
 	}
-	localPath := fmt.Sprintf("%s/config", localDir)
 	sshConfig := &ssh.ClientConfig{
 		User:            user,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
@@ -174,4 +172,13 @@ func sshAgent() ssh.AuthMethod {
 		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
 	}
 	return nil
+}
+
+func getKubeConfigPath(path string) (string, error) {	
+	if _, err := os.Stat(path); os.IsNotExist(err) {	
+			if err := os.Mkdir(path, 0777); err != nil {
+				return "", err
+			}
+	}
+	return fmt.Sprintf("%s/config", path), nil
 }

--- a/cutil/kubeconfig/kubeconfig.go
+++ b/cutil/kubeconfig/kubeconfig.go
@@ -35,7 +35,13 @@ func GetConfig(existing *cluster.Cluster) error {
 	pubKeyPath := local.Expand(existing.Ssh.PublicKeyPath)
 	privKeyPath := strings.Replace(pubKeyPath, ".pub", "", 1)
 	address := fmt.Sprintf("%s:%s", existing.KubernetesApi.Endpoint, "22")
-	localPath := fmt.Sprintf("%s/.kube/config", local.Home())
+	localDir := fmt.Sprintf("%s/.kube", local.Home())
+	if _, err := os.Stat(localDir); os.IsNotExist(err) {	
+			if err := os.Mkdir(localDir, 0777); err != nil {
+				return err
+			}
+	}
+	localPath := fmt.Sprintf("%s/config", localDir)
 	sshConfig := &ssh.ClientConfig{
 		User:            user,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),

--- a/cutil/kubeconfig/kubeconfig_test.go
+++ b/cutil/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeconfig
+
+import (
+	"io/ioutil"
+	"os"
+	"fmt"
+	"testing"
+)
+
+func TestMain(m *testing.M) {	
+	m.Run()
+}
+
+func TestSdkHappy(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {		
+		os.RemoveAll(tmpdir)
+	}()
+
+	localDir := fmt.Sprintf("%s/.kube", tmpdir)
+	localPath,err := getKubeConfigPath(localDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(localDir); os.IsNotExist(err) {
+		t.Fatal("error creating kubectl directory")
+	}
+
+	expectedLocalPath := fmt.Sprintf("%s/.kube/config", tmpdir)
+	if localPath != expectedLocalPath {
+		t.Fatalf("kubectl config path incorrect, got: %s, expected: %s", localPath, expectedLocalPath)
+	}
+}


### PR DESCRIPTION
Fixes issue that if you don't have `~/.kube` dir on local machine it will fail copying kubeconfig from the remote.