### PR TITLE
logger: disable lolgopher on windows

### DIFF
--- a/cutil/logger/fabulous.go
+++ b/cutil/logger/fabulous.go
@@ -1,0 +1,25 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package logger
+
+import (
+	"os"
+
+	lol "github.com/kris-nova/lolgopher"
+)
+
+var FabulousWriter = &lol.Writer{Output: os.Stdout, ColorMode: lol.ColorMode256}

--- a/cutil/logger/fabulous_windows.go
+++ b/cutil/logger/fabulous_windows.go
@@ -1,0 +1,22 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package logger
+
+import "os"
+
+// disable lolgopher for windows
+var FabulousWriter = os.Stdout

--- a/cutil/logger/logger.go
+++ b/cutil/logger/logger.go
@@ -19,17 +19,13 @@ import (
 	"github.com/fatih/color"
 	"strings"
 	"time"
-	"os"
-
-	lol "github.com/kris-nova/lolgopher"
 )
 
 var (
 	Level = 2
 	Color = true
 	TestMode = false
-	Fabulous = false
-	FabulousWriter = &lol.Writer{Output: os.Stdout, ColorMode: lol.ColorMode256}
+	Fabulous = false	
 )
 
 func Always(format string, a ...interface{}) {


### PR DESCRIPTION
lolgopher doesn't seem to work on Windows, due to ncurses.h library being not available for platform. When you try to build/install kubicorn, you will get the following error:
```
go\src\github.com\kris-nova\kubicorn\vendor\github.com\kris-nova\lolgopher\has_colors.go:4:11: fatal error: ncurses.h: No such file or directory
 // #include <ncurses.h>
           ^~~~~~~~~~~
compilation terminated.
```

This PR disables lolgopher for Windows.

Thanks to @MyDigitalLife for finding it out and providing logs.