### PR TITLE
Bash and Zsh completion for flags

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -52,11 +52,22 @@ type ApplyOptions struct {
 
 var ao = &ApplyOptions{}
 
-func init() {
-	RootCmd.AddCommand(applyCmd)
+func init() {	
 	applyCmd.Flags().StringVarP(&ao.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	applyCmd.Flags().StringVarP(&ao.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	applyCmd.Flags().StringVarP(&ao.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")
+
+	if applyCmd.Flag("name") != nil {
+			if applyCmd.Flag("name").Annotations == nil {
+				applyCmd.Flag("name").Annotations = map[string][]string{}
+			}
+			applyCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
+				applyCmd.Flag("name").Annotations[cobra.BashCompCustom],
+				"__kubicorn_parse_list",
+			)
+	}
+
+	RootCmd.AddCommand(applyCmd)
 }
 
 func RunApply(options *ApplyOptions) error {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -30,7 +30,7 @@ import (
 
 // applyCmd represents the apply command
 var applyCmd = &cobra.Command{
-	Use:   "apply",
+	Use:   "apply [-n|--name NAME]",
 	Short: "Apply a cluster resource to a cloud",
 	Long: `Use this command to apply an API model in a cloud.
 
@@ -57,15 +57,7 @@ func init() {
 	applyCmd.Flags().StringVarP(&ao.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	applyCmd.Flags().StringVarP(&ao.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")
 
-	if applyCmd.Flag("name") != nil {
-			if applyCmd.Flag("name").Annotations == nil {
-				applyCmd.Flag("name").Annotations = map[string][]string{}
-			}
-			applyCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
-				applyCmd.Flag("name").Annotations[cobra.BashCompCustom],
-				"__kubicorn_parse_list",
-			)
-	}
+	flagApplyAnnotations(applyCmd, "name", "__kubicorn_parse_list")
 
 	RootCmd.AddCommand(applyCmd)
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -52,7 +52,7 @@ type ApplyOptions struct {
 
 var ao = &ApplyOptions{}
 
-func init() {	
+func init() {
 	applyCmd.Flags().StringVarP(&ao.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	applyCmd.Flags().StringVarP(&ao.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	applyCmd.Flags().StringVarP(&ao.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -15,9 +15,9 @@
 package cmd
 
 import (
-	"github.com/kris-nova/kubicorn/cutil/logger"
 	"bytes"
 	"fmt"
+	"github.com/kris-nova/kubicorn/cutil/logger"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -77,7 +77,7 @@ line to your .profile or .bashrc/.zshrc:
 			return RunZshGeneration()
 		} else {
 			return fmt.Errorf("invalid shell argument")
-		}		
+		}
 	},
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -29,7 +29,7 @@ import (
 )
 
 var createCmd = &cobra.Command{
-	Use:   "create [-n|--name NAME]",
+	Use:   "create [-n|--name NAME] [-p|--profile PROFILENAME]",
 	Short: "Create a Kubicorn API model from a profile",
 	Long: `Use this command to create a Kubicorn API model in a defined state store.
 
@@ -66,6 +66,16 @@ func init() {
 			createCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
 				createCmd.Flag("name").Annotations[cobra.BashCompCustom],
 				"__kubicorn_parse_list",
+			)
+	}
+
+	if createCmd.Flag("profile") != nil {
+			if createCmd.Flag("profile").Annotations == nil {
+				createCmd.Flag("profile").Annotations = map[string][]string{}
+			}
+			createCmd.Flag("profile").Annotations[cobra.BashCompCustom] = append(
+				createCmd.Flag("profile").Annotations[cobra.BashCompCustom],
+				"__kubicorn_parse_profiles",
 			)
 	}
 	

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -43,7 +43,7 @@ After a model is defined and configured properly, the user can then apply the mo
 			os.Exit(1)
 		}
 
-	},	
+	},
 }
 
 type CreateOptions struct {
@@ -58,10 +58,10 @@ func init() {
 	createCmd.Flags().StringVarP(&co.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	createCmd.Flags().StringVarP(&co.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")
 	createCmd.Flags().StringVarP(&co.Profile, "profile", "p", strEnvDef("KUBICORN_PROFILE", "azure"), "The cluster profile to use")
-	
+
 	flagApplyAnnotations(createCmd, "name", "__kubicorn_parse_list")
 	flagApplyAnnotations(createCmd, "profile", "__kubicorn_parse_profiles")
-	
+
 	RootCmd.AddCommand(createCmd)
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -59,25 +59,8 @@ func init() {
 	createCmd.Flags().StringVarP(&co.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")
 	createCmd.Flags().StringVarP(&co.Profile, "profile", "p", strEnvDef("KUBICORN_PROFILE", "azure"), "The cluster profile to use")
 	
-	if createCmd.Flag("name") != nil {
-			if createCmd.Flag("name").Annotations == nil {
-				createCmd.Flag("name").Annotations = map[string][]string{}
-			}
-			createCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
-				createCmd.Flag("name").Annotations[cobra.BashCompCustom],
-				"__kubicorn_parse_list",
-			)
-	}
-
-	if createCmd.Flag("profile") != nil {
-			if createCmd.Flag("profile").Annotations == nil {
-				createCmd.Flag("profile").Annotations = map[string][]string{}
-			}
-			createCmd.Flag("profile").Annotations[cobra.BashCompCustom] = append(
-				createCmd.Flag("profile").Annotations[cobra.BashCompCustom],
-				"__kubicorn_parse_profiles",
-			)
-	}
+	flagApplyAnnotations(createCmd, "name", "__kubicorn_parse_list")
+	flagApplyAnnotations(createCmd, "profile", "__kubicorn_parse_profiles")
 	
 	RootCmd.AddCommand(createCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	//"github.com/spf13/pflag"
 	"fmt"
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/logger"
@@ -28,7 +29,7 @@ import (
 )
 
 var createCmd = &cobra.Command{
-	Use:   "create",
+	Use:   "create [-n|--name NAME]",
 	Short: "Create a Kubicorn API model from a profile",
 	Long: `Use this command to create a Kubicorn API model in a defined state store.
 
@@ -42,7 +43,7 @@ After a model is defined and configured properly, the user can then apply the mo
 			os.Exit(1)
 		}
 
-	},
+	},	
 }
 
 type CreateOptions struct {
@@ -57,6 +58,17 @@ func init() {
 	createCmd.Flags().StringVarP(&co.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	createCmd.Flags().StringVarP(&co.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")
 	createCmd.Flags().StringVarP(&co.Profile, "profile", "p", strEnvDef("KUBICORN_PROFILE", "azure"), "The cluster profile to use")
+	
+	if createCmd.Flag("name") != nil {
+			if createCmd.Flag("name").Annotations == nil {
+				createCmd.Flag("name").Annotations = map[string][]string{}
+			}
+			createCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
+				createCmd.Flag("name").Annotations[cobra.BashCompCustom],
+				"__kubicorn_parse_list",
+			)
+	}
+	
 	RootCmd.AddCommand(createCmd)
 }
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -59,6 +59,17 @@ func init() {
 	deleteCmd.Flags().StringVarP(&do.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	deleteCmd.Flags().StringVarP(&do.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "Cluster name to delete")
 	deleteCmd.Flags().BoolVarP(&do.Purge, "purge", "p", false, "Remove the API model from the state store after the resources are deleted.")
+
+	if deleteCmd.Flag("name") != nil {
+			if deleteCmd.Flag("name").Annotations == nil {
+				deleteCmd.Flag("name").Annotations = map[string][]string{}
+			}
+			deleteCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
+				deleteCmd.Flag("name").Annotations[cobra.BashCompCustom],
+				"__kubicorn_parse_list",
+			)
+	}
+	
 	RootCmd.AddCommand(deleteCmd)
 }
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -61,7 +61,7 @@ func init() {
 	deleteCmd.Flags().BoolVarP(&do.Purge, "purge", "p", false, "Remove the API model from the state store after the resources are deleted.")
 
 	flagApplyAnnotations(deleteCmd, "name", "__kubicorn_parse_list")
-	
+
 	RootCmd.AddCommand(deleteCmd)
 }
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -28,7 +28,7 @@ import (
 
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
-	Use:   "delete",
+	Use:   "delete [-n|--name NAME]",
 	Short: "Delete a Kubernetes cluster",
 	Long: `Use this command to delete cloud resources.
 
@@ -60,15 +60,7 @@ func init() {
 	deleteCmd.Flags().StringVarP(&do.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "Cluster name to delete")
 	deleteCmd.Flags().BoolVarP(&do.Purge, "purge", "p", false, "Remove the API model from the state store after the resources are deleted.")
 
-	if deleteCmd.Flag("name") != nil {
-			if deleteCmd.Flag("name").Annotations == nil {
-				deleteCmd.Flag("name").Annotations = map[string][]string{}
-			}
-			deleteCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
-				deleteCmd.Flag("name").Annotations[cobra.BashCompCustom],
-				"__kubicorn_parse_list",
-			)
-	}
+	flagApplyAnnotations(deleteCmd, "name", "__kubicorn_parse_list")
 	
 	RootCmd.AddCommand(deleteCmd)
 }

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -49,7 +49,7 @@ type GetConfigOptions struct {
 
 var cro = &GetConfigOptions{}
 
-func init() {	
+func init() {
 	getConfigCmd.Flags().StringVarP(&cro.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	getConfigCmd.Flags().StringVarP(&cro.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	getConfigCmd.Flags().StringVarP(&cro.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -49,11 +49,22 @@ type GetConfigOptions struct {
 
 var cro = &GetConfigOptions{}
 
-func init() {
-	RootCmd.AddCommand(getConfigCmd)
+func init() {	
 	getConfigCmd.Flags().StringVarP(&cro.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	getConfigCmd.Flags().StringVarP(&cro.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	getConfigCmd.Flags().StringVarP(&cro.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")
+
+	if getConfigCmd.Flag("name") != nil {
+			if getConfigCmd.Flag("name").Annotations == nil {
+				getConfigCmd.Flag("name").Annotations = map[string][]string{}
+			}
+			getConfigCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
+				getConfigCmd.Flag("name").Annotations[cobra.BashCompCustom],
+				"__kubicorn_parse_list",
+			)
+	}
+
+	RootCmd.AddCommand(getConfigCmd)
 }
 
 func RunGetConfig(options *GetConfigOptions) error {

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -28,7 +28,7 @@ import (
 
 // getConfigCmd represents the apply command
 var getConfigCmd = &cobra.Command{
-	Use:   "getconfig",
+	Use:   "getconfig [-n|--name NAME]",
 	Short: "Manage Kubernetes configuration",
 	Long: `Use this command to pull a kubeconfig file from a cluster so you can use kubectl.
 
@@ -54,15 +54,7 @@ func init() {
 	getConfigCmd.Flags().StringVarP(&cro.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	getConfigCmd.Flags().StringVarP(&cro.Name, "name", "n", strEnvDef("KUBICORN_NAME", ""), "An optional name to use. If empty, will generate a random name.")
 
-	if getConfigCmd.Flag("name") != nil {
-			if getConfigCmd.Flag("name").Annotations == nil {
-				getConfigCmd.Flag("name").Annotations = map[string][]string{}
-			}
-			getConfigCmd.Flag("name").Annotations[cobra.BashCompCustom] = append(
-				getConfigCmd.Flag("name").Annotations[cobra.BashCompCustom],
-				"__kubicorn_parse_list",
-			)
-	}
+	flagApplyAnnotations(getConfigCmd, "name", "__kubicorn_parse_list")
 
 	RootCmd.AddCommand(getConfigCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,7 +39,7 @@ var listCmd = &cobra.Command{
 
 type ListOptions struct {
 	Options
-	Profile string	
+	Profile string
 }
 
 var lo = &ListOptions{}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,14 +39,17 @@ var listCmd = &cobra.Command{
 
 type ListOptions struct {
 	Options
-	Profile string
+	Profile string	
 }
 
 var lo = &ListOptions{}
 
+var noHeaders bool
+
 func init() {
 	listCmd.Flags().StringVarP(&lo.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	listCmd.Flags().StringVarP(&lo.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
+	listCmd.Flags().BoolVarP(&noHeaders, "no-headers", "n", false, "Show the list containing names only")
 	RootCmd.AddCommand(listCmd)
 
 }
@@ -57,7 +60,9 @@ func RunList(options *ListOptions) error {
 	var stateStore state.ClusterStorer
 	switch options.StateStore {
 	case "fs":
-		logger.Info("Selected [fs] state store")
+		if !noHeaders {
+			logger.Info("Selected [fs] state store")
+		}
 		stateStore = fs.NewFileSystemStore(&fs.FileSystemStoreOptions{
 			BasePath: options.StateStorePath,
 		})
@@ -68,7 +73,11 @@ func RunList(options *ListOptions) error {
 		return fmt.Errorf("Unable to list clusters: %v", err)
 	}
 	for _, cluster := range clusters {
-		logger.Always(cluster)
+		if !noHeaders {
+			logger.Always(cluster)
+		} else {
+			fmt.Println(cluster)
+		}
 	}
 
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,20 +23,13 @@ import (
 )
 
 const (
-	bashCompletionFunc = `# call kubectl get $1,
+	bashCompletionFunc = `
 __kubicorn_parse_list()
 {
     local kubicorn_out
     if kubicorn_out=$(kubicorn list --no-headers 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${kubicorn_out[*]}" -- "$cur" ) )
     fi
-}
-__kubicorn_list_resource()
-{
-    if [[ ${#nouns[@]} -eq 0 ]]; then
-        return 1
-    fi
-    __kubicorn_parse_list "${nouns[${#nouns[@]} -1]}"
 }
 __kubicorn_parse_profiles()
 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,13 @@ __kubicorn_list_resource()
     fi
     __kubicorn_parse_list "${nouns[${#nouns[@]} -1]}"
 }
+__kubicorn_parse_profiles()
+{
+    local kubicorn_out
+    if kubicorn_out=(amazon aws digitalocean do); then
+        COMPREPLY=( $( compgen -W "${kubicorn_out[*]}" -- "$cur" ) )
+    fi
+}
 `
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,9 +17,9 @@ package cmd
 import (
 	"fmt"
 	"github.com/kris-nova/kubicorn/cutil/logger"
+	lol "github.com/kris-nova/lolgopher"
 	"github.com/spf13/cobra"
 	"os"
-	lol "github.com/kris-nova/lolgopher"
 )
 
 const (
@@ -83,8 +83,6 @@ func init() {
 
 	// register env vars
 	registerEnvironmentalVariables()
-
-	
 }
 
 func registerEnvironmentalVariables() {
@@ -93,12 +91,12 @@ func registerEnvironmentalVariables() {
 
 func flagApplyAnnotations(cmd *cobra.Command, flag, completion string) {
 	if cmd.Flag(flag) != nil {
-			if cmd.Flag(flag).Annotations == nil {
-				cmd.Flag(flag).Annotations = map[string][]string{}
-			}
-			cmd.Flag(flag).Annotations[cobra.BashCompCustom] = append(
-				cmd.Flag(flag).Annotations[cobra.BashCompCustom],
-				completion,
-			)
+		if cmd.Flag(flag).Annotations == nil {
+			cmd.Flag(flag).Annotations = map[string][]string{}
+		}
+		cmd.Flag(flag).Annotations[cobra.BashCompCustom] = append(
+			cmd.Flag(flag).Annotations[cobra.BashCompCustom],
+			completion,
+		)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,25 @@ import (
 	lol "github.com/kris-nova/lolgopher"
 )
 
+const (
+	bashCompletionFunc = `# call kubectl get $1,
+__kubicorn_parse_list()
+{
+    local kubicorn_out
+    if kubicorn_out=$(kubicorn list --no-headers 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${kubicorn_out[*]}" -- "$cur" ) )
+    fi
+}
+__kubicorn_list_resource()
+{
+    if [[ ${#nouns[@]} -eq 0 ]]; then
+        return 1
+    fi
+    __kubicorn_parse_list "${nouns[${#nouns[@]} -1]}"
+}
+`
+)
+
 var cfgFile string
 
 // RootCmd represents the base command when called without any subcommands
@@ -39,7 +58,8 @@ var RootCmd = &cobra.Command{
 			cmd.SetOutput(&lol.Writer{Output: os.Stdout, ColorMode: lol.ColorModeTrueColor})
 		}
 		cmd.Help()
-	},	
+	},
+	BashCompletionFunction: bashCompletionFunc,
 }
 
 type Options struct {
@@ -63,6 +83,8 @@ func init() {
 
 	// register env vars
 	registerEnvironmentalVariables()
+
+	
 }
 
 func registerEnvironmentalVariables() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,3 +90,15 @@ func init() {
 func registerEnvironmentalVariables() {
 
 }
+
+func flagApplyAnnotations(cmd *cobra.Command, flag, completion string) {
+	if cmd.Flag(flag) != nil {
+			if cmd.Flag(flag).Annotations == nil {
+				cmd.Flag(flag).Annotations = map[string][]string{}
+			}
+			cmd.Flag(flag).Annotations[cobra.BashCompCustom] = append(
+				cmd.Flag(flag).Annotations[cobra.BashCompCustom],
+				completion,
+			)
+	}
+}


### PR DESCRIPTION
Fixes #128 
Fixes #26 

Downsides:
* Current version supports only `./_state` or using environmental variables. This should not be a big thing, even if it stays.
* Profiles are typed in as constant. We will fix this once we better know how we will manage profiles. We will probably need an command to list all profiles.

Available for `--name` and `--profile` flags.