### PR TITLE
Renamed variable names to fix lint warnings

### DIFF
--- a/apis/cluster/api.go
+++ b/apis/cluster/api.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type KubernetesApi struct {
+type KubernetesAPI struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Endpoint          string

--- a/apis/cluster/auth.go
+++ b/apis/cluster/auth.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type Ssh struct {
+type SSH struct {
 	metav1.TypeMeta      `json:",inline"`
 	metav1.ObjectMeta    `json:"metadata,omitempty"`
 	Name                 string

--- a/apis/cluster/cluster.go
+++ b/apis/cluster/cluster.go
@@ -19,24 +19,24 @@ import (
 )
 
 const (
-	Cloud_Amazon       = "amazon"
-	Cloud_Azure        = "azure"
-	Cloud_Google       = "google"
-	Cloud_Baremetal    = "baremetal"
-	Cloud_DigitalOcean = "digitalocean"
+	CloudAmazon       = "amazon"
+	CloudAzure        = "azure"
+	CloudGoogle       = "google"
+	CloudBaremetal    = "baremetal"
+	CloudDigitalOcean = "digitalocean"
 )
 
 type Cluster struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Name              string
-	ServerPools       []*ServerPool
-	Cloud             string
-	Location          string
-	Ssh               *Ssh
-	Network           *Network
-	Values            *Values
-	KubernetesApi     *KubernetesApi
+	Name          string
+	ServerPools   []*ServerPool
+	Cloud         string
+	Location      string
+	SSH           *SSH
+	Network       *Network
+	Values        *Values
+	KubernetesAPI *KubernetesAPI
 }
 
 func NewCluster(name string) *Cluster {

--- a/apis/cluster/network.go
+++ b/apis/cluster/network.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	NetworkType_Local   = "local"
-	NetworkType_Public  = "public"
-	NetworkType_Private = "private"
+	NetworkTypeLocal   = "local"
+	NetworkTypePublic  = "public"
+	NetworkTypePrivate = "private"
 )
 
 type Network struct {

--- a/apis/cluster/serverpool.go
+++ b/apis/cluster/serverpool.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	ServerPoolType_Master = "master"
-	ServerPoolType_Node   = "node"
-	ServerPoolType_Hybrid = "hybrid"
+	ServerPoolTypeMaster = "master"
+	ServerPoolTypeNode   = "node"
+	ServerPoolTypeHybrid = "hybrid"
 )
 
 type ServerPool struct {

--- a/cloud/amazon/reconciler.go
+++ b/cloud/amazon/reconciler.go
@@ -93,7 +93,7 @@ func cleanUp(cluster *cluster.Cluster, i int) error {
 		createdResource := createdResources[j]
 		err := resource.Delete(createdResource, cluster)
 		if err != nil {
-			err, j = destroyI(err, j)
+			j, err = destroyI(err, j)
 			if err != nil {
 				return err
 			}
@@ -157,16 +157,16 @@ var hg = &hang.Hanger{
 	Ratio: 1,
 }
 
-func destroyI(err error, i int) (error, int) {
+func destroyI(err error, i int) (int, error) {
 	hg.Hang()
 	for _, retryString := range destroyRetryStrings {
 		if strings.Contains(err.Error(), retryString) {
 			logger.Debug("Retry failed delete: %v", err)
 			time.Sleep(1 * time.Second)
-			return nil, i + 1
+			return i + 1, nil
 		}
 	}
-	return err, 0
+	return 0, err
 }
 
 func (r *Reconciler) Destroy() error {
@@ -174,7 +174,7 @@ func (r *Reconciler) Destroy() error {
 		resource := model[i]
 		actualResource, err := resource.Actual(r.Known)
 		if err != nil {
-			err, i = destroyI(err, i)
+			i, err = destroyI(err, i)
 			if err != nil {
 				return err
 			}
@@ -182,7 +182,7 @@ func (r *Reconciler) Destroy() error {
 		}
 		err = resource.Delete(actualResource, r.Known)
 		if err != nil {
-			err, i = destroyI(err, i)
+			i, err = destroyI(err, i)
 			if err != nil {
 				return err
 			}
@@ -198,9 +198,9 @@ func newClusterDefaults(base *cluster.Cluster) *cluster.Cluster {
 		Cloud:         base.Cloud,
 		Location:      base.Location,
 		Network:       &cluster.Network{},
-		Ssh:           &cluster.Ssh{},
+		SSH:           &cluster.SSH{},
 		Values:        base.Values,
-		KubernetesApi: base.KubernetesApi,
+		KubernetesAPI: base.KubernetesAPI,
 	}
 	return new
 }

--- a/cloud/amazon/resources/autoscalegroup.go
+++ b/cloud/amazon/resources/autoscalegroup.go
@@ -106,17 +106,17 @@ func (r *Asg) Apply(actual, expected cloud.Resource, applyCluster *cluster.Clust
 	if isEqual {
 		return applyResource, nil
 	}
-	subnetId := ""
+	subnetID := ""
 	for _, sp := range applyCluster.ServerPools {
 		if sp.Name == r.Name {
 			for _, sn := range sp.Subnets {
 				if sn.Name == r.Name {
-					subnetId = sn.Identifier
+					subnetID = sn.Identifier
 				}
 			}
 		}
 	}
-	if subnetId == "" {
+	if subnetID == "" {
 		return nil, fmt.Errorf("Unable to find subnet id")
 	}
 
@@ -126,7 +126,7 @@ func (r *Asg) Apply(actual, expected cloud.Resource, applyCluster *cluster.Clust
 		MinSize:                 I64(expected.(*Asg).MinCount),
 		MaxSize:                 I64(expected.(*Asg).MaxCount),
 		LaunchConfigurationName: &r.Name,
-		VPCZoneIdentifier:       &subnetId,
+		VPCZoneIdentifier:       &subnetID,
 	}
 	_, err = Sdk.ASG.CreateAutoScalingGroup(input)
 	if err != nil {

--- a/cloud/amazon/resources/keypair.go
+++ b/cloud/amazon/resources/keypair.go
@@ -45,9 +45,9 @@ func (r *KeyPair) Actual(known *cluster.Cluster) (cloud.Resource, error) {
 		},
 	}
 
-	if known.Ssh.Identifier != "" {
+	if known.SSH.Identifier != "" {
 		input := &ec2.DescribeKeyPairsInput{
-			KeyNames: []*string{&known.Ssh.Identifier},
+			KeyNames: []*string{&known.SSH.Identifier},
 		}
 		output, err := Sdk.Ec2.DescribeKeyPairs(input)
 		if err != nil {
@@ -55,13 +55,13 @@ func (r *KeyPair) Actual(known *cluster.Cluster) (cloud.Resource, error) {
 		}
 		lsn := len(output.KeyPairs)
 		if lsn != 1 {
-			return nil, fmt.Errorf("Found [%d] Keypairs for ID [%s]", lsn, known.Ssh.Identifier)
+			return nil, fmt.Errorf("Found [%d] Keypairs for ID [%s]", lsn, known.SSH.Identifier)
 		}
 		keypair := output.KeyPairs[0]
 		actual.CloudID = *keypair.KeyName
 		actual.PublicKeyFingerprint = *keypair.KeyFingerprint
 	}
-	actual.User = known.Ssh.User
+	actual.User = known.SSH.User
 	r.CachedActual = actual
 	return actual, nil
 }
@@ -78,13 +78,13 @@ func (r *KeyPair) Expected(known *cluster.Cluster) (cloud.Resource, error) {
 				"Name":              r.Name,
 				"KubernetesCluster": known.Name,
 			},
-			CloudID:     known.Ssh.Identifier,
+			CloudID:     known.SSH.Identifier,
 			Name:        r.Name,
 			TagResource: r.TagResource,
 		},
-		PublicKeyPath: known.Ssh.PublicKeyPath,
-		PublicKeyData: string(known.Ssh.PublicKeyData),
-		User:          known.Ssh.User,
+		PublicKeyPath: known.SSH.PublicKeyPath,
+		PublicKeyData: string(known.SSH.PublicKeyData),
+		User:          known.SSH.User,
 	}
 	r.CachedExpected = expected
 	return expected, nil
@@ -138,12 +138,12 @@ func (r *KeyPair) Delete(actual cloud.Resource, known *cluster.Cluster) error {
 
 func (r *KeyPair) Render(renderResource cloud.Resource, renderCluster *cluster.Cluster) (*cluster.Cluster, error) {
 	logger.Debug("keypair.Render")
-	renderCluster.Ssh.Name = renderResource.(*KeyPair).Name
-	renderCluster.Ssh.Identifier = renderResource.(*KeyPair).Name
-	renderCluster.Ssh.PublicKeyData = []byte(renderResource.(*KeyPair).PublicKeyData)
-	renderCluster.Ssh.PublicKeyFingerprint = renderResource.(*KeyPair).PublicKeyFingerprint
-	renderCluster.Ssh.PublicKeyPath = renderResource.(*KeyPair).PublicKeyPath
-	renderCluster.Ssh.User = renderResource.(*KeyPair).User
+	renderCluster.SSH.Name = renderResource.(*KeyPair).Name
+	renderCluster.SSH.Identifier = renderResource.(*KeyPair).Name
+	renderCluster.SSH.PublicKeyData = []byte(renderResource.(*KeyPair).PublicKeyData)
+	renderCluster.SSH.PublicKeyFingerprint = renderResource.(*KeyPair).PublicKeyFingerprint
+	renderCluster.SSH.PublicKeyPath = renderResource.(*KeyPair).PublicKeyPath
+	renderCluster.SSH.User = renderResource.(*KeyPair).User
 	return renderCluster, nil
 }
 

--- a/cloud/amazon/resources/launchconfiguration.go
+++ b/cloud/amazon/resources/launchconfiguration.go
@@ -36,8 +36,8 @@ type Lc struct {
 }
 
 const (
-	MasterIpAttempts               = 40
-	MasterIpSleepSecondsPerAttempt = 3
+	MasterIPAttempts               = 40
+	MasterIPSleepSecondsPerAttempt = 3
 )
 
 func (r *Lc) Actual(known *cluster.Cluster) (cloud.Resource, error) {
@@ -150,7 +150,7 @@ func (r *Lc) Apply(actual, expected cloud.Resource, applyCluster *cluster.Cluste
 			lr := len(output.Reservations)
 			if lr == 0 {
 				logger.Debug("Found [%d] Reservations, hanging ", lr)
-				time.Sleep(time.Duration(MasterIpSleepSecondsPerAttempt) * time.Second)
+				time.Sleep(time.Duration(MasterIPSleepSecondsPerAttempt) * time.Second)
 				continue
 			}
 			for _, reservation := range output.Reservations {
@@ -158,8 +158,8 @@ func (r *Lc) Apply(actual, expected cloud.Resource, applyCluster *cluster.Cluste
 					if instance.PublicIpAddress != nil {
 						privip = *instance.PrivateIpAddress
 						pubip = *instance.PublicIpAddress
-						applyCluster.Values.ItemMap["INJECTEDMASTER"] = fmt.Sprintf("%s:%s", privip, applyCluster.KubernetesApi.Port)
-						applyCluster.KubernetesApi.Endpoint = pubip
+						applyCluster.Values.ItemMap["INJECTEDMASTER"] = fmt.Sprintf("%s:%s", privip, applyCluster.KubernetesAPI.Port)
+						applyCluster.KubernetesAPI.Endpoint = pubip
 						logger.Info("Found public IP for master: [%s]", pubip)
 						found = true
 					}
@@ -168,7 +168,7 @@ func (r *Lc) Apply(actual, expected cloud.Resource, applyCluster *cluster.Cluste
 			if found == true {
 				break
 			}
-			time.Sleep(time.Duration(MasterIpSleepSecondsPerAttempt) * time.Second)
+			time.Sleep(time.Duration(MasterIPSleepSecondsPerAttempt) * time.Second)
 		}
 		if !found {
 			return nil, fmt.Errorf("Unable to find Master IP")
@@ -182,7 +182,7 @@ func (r *Lc) Apply(actual, expected cloud.Resource, applyCluster *cluster.Cluste
 	}
 
 	//fmt.Println(string(userData))
-	applyCluster.Values.ItemMap["INJECTEDPORT"] = applyCluster.KubernetesApi.Port
+	applyCluster.Values.ItemMap["INJECTEDPORT"] = applyCluster.KubernetesAPI.Port
 	userData, err = bootstrap.Inject(userData, applyCluster.Values.ItemMap)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func (r *Lc) Apply(actual, expected cloud.Resource, applyCluster *cluster.Cluste
 		LaunchConfigurationName:  &expected.(*Lc).Name,
 		ImageId:                  &expected.(*Lc).Image,
 		InstanceType:             &expected.(*Lc).InstanceType,
-		KeyName:                  &applyCluster.Ssh.Identifier,
+		KeyName:                  &applyCluster.SSH.Identifier,
 		SecurityGroups:           sgs,
 		UserData:                 &b64data,
 	}

--- a/cloud/amazon/resources/routetable.go
+++ b/cloud/amazon/resources/routetable.go
@@ -146,23 +146,23 @@ func (r *RouteTable) Apply(actual, expected cloud.Resource, applyCluster *cluste
 		return nil, err
 	}
 
-	subnetId := ""
+	subnetID := ""
 	for _, sp := range applyCluster.ServerPools {
 		if sp.Name == r.Name {
 			for _, sn := range sp.Subnets {
 				if sn.Name == r.Name {
-					subnetId = sn.Identifier
+					subnetID = sn.Identifier
 				}
 			}
 		}
 	}
-	if subnetId == "" {
+	if subnetID == "" {
 		return nil, fmt.Errorf("Unable to find subnet id")
 	}
 
 	// --- Associate Route table to this particular subnet
 	asInput := &ec2.AssociateRouteTableInput{
-		SubnetId:     &subnetId,
+		SubnetId:     &subnetID,
 		RouteTableId: rtOutput.RouteTable.RouteTableId,
 	}
 	_, err = Sdk.Ec2.AssociateRouteTable(asInput)
@@ -175,7 +175,7 @@ func (r *RouteTable) Apply(actual, expected cloud.Resource, applyCluster *cluste
 	if err != nil {
 		return nil, err
 	}
-	logger.Info("Associated route table [%s] to subnet [%s]", *rtOutput.RouteTable.RouteTableId, subnetId)
+	logger.Info("Associated route table [%s] to subnet [%s]", *rtOutput.RouteTable.RouteTableId, subnetID)
 	newResource := &RouteTable{}
 	newResource.CloudID = expected.(*RouteTable).CloudID
 	newResource.Name = expected.(*RouteTable).Name

--- a/cloud/amazon/resources/securitygroup.go
+++ b/cloud/amazon/resources/securitygroup.go
@@ -37,7 +37,7 @@ type SecurityGroup struct {
 }
 
 const (
-	KUBICORN_AUTO_CREATED_GROUP = "A FABULOUS security group created by Kubicorn for cluster [%s]"
+	KubicornAutoCreatedGroup = "A FABULOUS security group created by Kubicorn for cluster [%s]"
 )
 
 func (r *SecurityGroup) Actual(known *cluster.Cluster) (cloud.Resource, error) {
@@ -129,7 +129,7 @@ func (r *SecurityGroup) Apply(actual, expected cloud.Resource, applyCluster *clu
 	input := &ec2.CreateSecurityGroupInput{
 		GroupName:   &expected.(*SecurityGroup).Name,
 		VpcId:       &applyCluster.Network.Identifier,
-		Description: S(fmt.Sprintf(KUBICORN_AUTO_CREATED_GROUP, applyCluster.Name)),
+		Description: S(fmt.Sprintf(KubicornAutoCreatedGroup, applyCluster.Name)),
 	}
 	output, err := Sdk.Ec2.CreateSecurityGroup(input)
 	if err != nil {

--- a/cloud/amazon/resources/subnet.go
+++ b/cloud/amazon/resources/subnet.go
@@ -28,7 +28,7 @@ type Subnet struct {
 	ClusterSubnet *cluster.Subnet
 	ServerPool    *cluster.ServerPool
 	CIDR          string
-	VpcId         string
+	VpcID         string
 	Zone          string
 }
 
@@ -61,7 +61,7 @@ func (r *Subnet) Actual(known *cluster.Cluster) (cloud.Resource, error) {
 		subnet := output.Subnets[0]
 		actual.CIDR = *subnet.CidrBlock
 		actual.CloudID = *subnet.SubnetId
-		actual.VpcId = *subnet.VpcId
+		actual.VpcID = *subnet.VpcId
 		actual.Zone = *subnet.AvailabilityZone
 		for _, tag := range subnet.Tags {
 			key := *tag.Key
@@ -91,7 +91,7 @@ func (r *Subnet) Expected(known *cluster.Cluster) (cloud.Resource, error) {
 			TagResource: r.TagResource,
 		},
 		CIDR:  r.ClusterSubnet.CIDR,
-		VpcId: known.Network.Identifier,
+		VpcID: known.Network.Identifier,
 		Zone:  r.ClusterSubnet.Zone,
 	}
 	r.CachedExpected = expected
@@ -119,7 +119,7 @@ func (r *Subnet) Apply(actual, expected cloud.Resource, applyCluster *cluster.Cl
 	logger.Info("Created Subnet [%s]", *output.Subnet.SubnetId)
 	newResource := &Subnet{}
 	newResource.CIDR = *output.Subnet.CidrBlock
-	newResource.VpcId = *output.Subnet.VpcId
+	newResource.VpcID = *output.Subnet.VpcId
 	newResource.Zone = *output.Subnet.AvailabilityZone
 	newResource.Name = applyResource.Name
 	newResource.CloudID = *output.Subnet.SubnetId

--- a/cloud/digitalocean/reconciler.go
+++ b/cloud/digitalocean/reconciler.go
@@ -93,7 +93,7 @@ func cleanUp(cluster *cluster.Cluster, i int) error {
 		createdResource := createdResources[j]
 		err := resource.Delete(createdResource, cluster)
 		if err != nil {
-			err, j = destroyI(err, j)
+			j, err = destroyI(err, j)
 			if err != nil {
 				return err
 			}
@@ -157,16 +157,16 @@ var hg = &hang.Hanger{
 	Ratio: 1,
 }
 
-func destroyI(err error, i int) (error, int) {
+func destroyI(err error, i int) (int, error) {
 	hg.Hang()
 	for _, retryString := range destroyRetryStrings {
 		if strings.Contains(err.Error(), retryString) {
 			logger.Debug("Retry failed delete: %v", err)
 			time.Sleep(1 * time.Second)
-			return nil, i + 1
+			return i + 1, nil
 		}
 	}
-	return err, 0
+	return 0, err
 }
 
 func (r *Reconciler) Destroy() error {
@@ -174,7 +174,7 @@ func (r *Reconciler) Destroy() error {
 		resource := model[i]
 		actualResource, err := resource.Actual(r.Known)
 		if err != nil {
-			err, i = destroyI(err, i)
+			i, err = destroyI(err, i)
 			if err != nil {
 				return err
 			}
@@ -182,7 +182,7 @@ func (r *Reconciler) Destroy() error {
 		}
 		err = resource.Delete(actualResource, r.Known)
 		if err != nil {
-			err, i = destroyI(err, i)
+			i, err = destroyI(err, i)
 			if err != nil {
 				return err
 			}
@@ -198,9 +198,9 @@ func newClusterDefaults(base *cluster.Cluster) *cluster.Cluster {
 		Cloud:         base.Cloud,
 		Location:      base.Location,
 		Network:       &cluster.Network{},
-		Ssh:           &cluster.Ssh{},
+		SSH:           &cluster.SSH{},
 		Values:        base.Values,
-		KubernetesApi: base.KubernetesApi,
+		KubernetesAPI: base.KubernetesAPI,
 		//ServerPools:   base.ServerPools,
 	}
 	return new

--- a/cloud/digitalocean/resources/ssh.go
+++ b/cloud/digitalocean/resources/ssh.go
@@ -42,9 +42,9 @@ func (r *SSH) Actual(known *cluster.Cluster) (cloud.Resource, error) {
 	actual := &SSH{
 		Shared: Shared{
 			Name:    r.Name,
-			CloudID: known.Ssh.Identifier,
+			CloudID: known.SSH.Identifier,
 		},
-		User: known.Ssh.User,
+		User: known.SSH.User,
 	}
 
 	if r.CloudID != "" {
@@ -61,7 +61,7 @@ func (r *SSH) Actual(known *cluster.Cluster) (cloud.Resource, error) {
 		actual.Name = ssh.Name
 		actual.CloudID = strid
 		actual.PublicKeyFingerprint = ssh.Fingerprint
-		actual.PublicKeyPath = known.Ssh.PublicKeyPath
+		actual.PublicKeyPath = known.SSH.PublicKeyPath
 		actual.PublicKeyData = ssh.PublicKey
 	}
 	r.CachedActual = actual
@@ -77,12 +77,12 @@ func (r *SSH) Expected(known *cluster.Cluster) (cloud.Resource, error) {
 	expected := &SSH{
 		Shared: Shared{
 			Name:    r.Name,
-			CloudID: known.Ssh.Identifier,
+			CloudID: known.SSH.Identifier,
 		},
-		PublicKeyFingerprint: known.Ssh.PublicKeyFingerprint,
-		PublicKeyData:        string(known.Ssh.PublicKeyData),
-		PublicKeyPath:        known.Ssh.PublicKeyPath,
-		User:                 known.Ssh.User,
+		PublicKeyFingerprint: known.SSH.PublicKeyFingerprint,
+		PublicKeyData:        string(known.SSH.PublicKeyData),
+		PublicKeyPath:        known.SSH.PublicKeyPath,
+		User:                 known.SSH.User,
 	}
 	r.CachedExpected = expected
 	return expected, nil
@@ -130,7 +130,7 @@ func (r *SSH) Delete(actual cloud.Resource, known *cluster.Cluster) error {
 	if deleteResource.CloudID == "" {
 		return fmt.Errorf("Unable to delete ssh resource without Id [%s]", deleteResource.Name)
 	}
-	id, err := strconv.Atoi(known.Ssh.Identifier)
+	id, err := strconv.Atoi(known.SSH.Identifier)
 	if err != nil {
 		return err
 	}
@@ -146,11 +146,11 @@ func (r *SSH) Delete(actual cloud.Resource, known *cluster.Cluster) error {
 
 func (r *SSH) Render(renderResource cloud.Resource, renderCluster *cluster.Cluster) (*cluster.Cluster, error) {
 	logger.Debug("ssh.Render")
-	renderCluster.Ssh.PublicKeyData = []byte(renderResource.(*SSH).PublicKeyData)
-	renderCluster.Ssh.PublicKeyFingerprint = renderResource.(*SSH).PublicKeyFingerprint
-	renderCluster.Ssh.PublicKeyPath = renderResource.(*SSH).PublicKeyPath
-	renderCluster.Ssh.Identifier = renderResource.(*SSH).CloudID
-	renderCluster.Ssh.User = renderResource.(*SSH).User
+	renderCluster.SSH.PublicKeyData = []byte(renderResource.(*SSH).PublicKeyData)
+	renderCluster.SSH.PublicKeyFingerprint = renderResource.(*SSH).PublicKeyFingerprint
+	renderCluster.SSH.PublicKeyPath = renderResource.(*SSH).PublicKeyPath
+	renderCluster.SSH.Identifier = renderResource.(*SSH).CloudID
+	renderCluster.SSH.User = renderResource.(*SSH).User
 	return renderCluster, nil
 }
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -64,7 +64,7 @@ func RunApply(options *ApplyOptions) error {
 	// Ensure we have a name
 	name := options.Name
 	if name == "" {
-		return errors.New("Empty name. Must specify the name of the cluster to apply.")
+		return errors.New("Empty name. Must specify the name of the cluster to apply")
 	}
 
 	// Expand state store path
@@ -131,8 +131,8 @@ func RunApply(options *ApplyOptions) error {
 
 	logger.Always("The [%s] cluster has applied successfully!", newCluster.Name)
 	logger.Always("You can now `kubectl get nodes`")
-	privKeyPath := strings.Replace(cluster.Ssh.PublicKeyPath, ".pub", "", 1)
-	logger.Always("You can SSH into your cluster ssh -i %s %s@%s", privKeyPath, newCluster.Ssh.User, newCluster.KubernetesApi.Endpoint)
+	privKeyPath := strings.Replace(cluster.SSH.PublicKeyPath, ".pub", "", 1)
+	logger.Always("You can SSH into your cluster ssh -i %s %s@%s", privKeyPath, newCluster.SSH.User, newCluster.KubernetesAPI.Endpoint)
 
 	return nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -67,7 +67,7 @@ func RunDelete(options *DeleteOptions) error {
 	// Ensure we have a name
 	name := options.Name
 	if name == "" {
-		return errors.New("Empty name. Must specify the name of the cluster to delete.")
+		return errors.New("Empty name. Must specify the name of the cluster to delete")
 	}
 	// Expand state store path
 	options.StateStorePath = expandPath(options.StateStorePath)

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -61,7 +61,7 @@ func RunGetConfig(options *GetConfigOptions) error {
 	// Ensure we have a name
 	name := options.Name
 	if name == "" {
-		return errors.New("Empty name. Must specify the name of the cluster to get config.")
+		return errors.New("Empty name. Must specify the name of the cluster to get config")
 	}
 
 	// Expand state store path

--- a/cutil/initapi/ssh.go
+++ b/cutil/initapi/ssh.go
@@ -28,13 +28,13 @@ import (
 )
 
 func sshLoader(initCluster *cluster.Cluster) (*cluster.Cluster, error) {
-	if initCluster.Ssh.PublicKeyPath != "" {
-		bytes, err := ioutil.ReadFile(local.Expand(initCluster.Ssh.PublicKeyPath))
+	if initCluster.SSH.PublicKeyPath != "" {
+		bytes, err := ioutil.ReadFile(local.Expand(initCluster.SSH.PublicKeyPath))
 		if err != nil {
 			return nil, err
 		}
-		initCluster.Ssh.PublicKeyData = bytes
-		privateBytes, err := ioutil.ReadFile(strings.Replace(local.Expand(initCluster.Ssh.PublicKeyPath), ".pub", "", 1))
+		initCluster.SSH.PublicKeyData = bytes
+		privateBytes, err := ioutil.ReadFile(strings.Replace(local.Expand(initCluster.SSH.PublicKeyPath), ".pub", "", 1))
 		if err != nil {
 			return nil, err
 		}
@@ -42,7 +42,7 @@ func sshLoader(initCluster *cluster.Cluster) (*cluster.Cluster, error) {
 		if err != nil {
 			return nil, err
 		}
-		initCluster.Ssh.PublicKeyFingerprint = fp
+		initCluster.SSH.PublicKeyFingerprint = fp
 	}
 
 	return initCluster, nil
@@ -86,10 +86,10 @@ func GetSigner(pemBytes []byte) (ssh.Signer, error) {
 		signerwithpassphrase, err := ssh.ParsePrivateKeyWithPassphrase(pemBytes, passPhrase)
 		if err != nil {
 			return nil, err
-		} else {
-			return signerwithpassphrase, err
 		}
-	} else {
-		return signerwithoutpassphrase, err
+
+		return signerwithpassphrase, err
 	}
+
+	return signerwithoutpassphrase, err
 }

--- a/cutil/kubeconfig/kubeconfig.go
+++ b/cutil/kubeconfig/kubeconfig.go
@@ -32,10 +32,10 @@ import (
 )
 
 func GetConfig(existing *cluster.Cluster) error {
-	user := existing.Ssh.User
-	pubKeyPath := local.Expand(existing.Ssh.PublicKeyPath)
+	user := existing.SSH.User
+	pubKeyPath := local.Expand(existing.SSH.PublicKeyPath)
 	privKeyPath := strings.Replace(pubKeyPath, ".pub", "", 1)
-	address := fmt.Sprintf("%s:%s", existing.KubernetesApi.Endpoint, "22")
+	address := fmt.Sprintf("%s:%s", existing.KubernetesAPI.Endpoint, "22")
 	localDir := fmt.Sprintf("%s/.kube", local.Home())
 	localPath, err := getKubeConfigPath(localDir)
 	if err != nil {
@@ -160,12 +160,12 @@ func GetSigner(pemBytes []byte) (ssh.Signer, error) {
 		signerwithpassphrase, err := ssh.ParsePrivateKeyWithPassphrase(pemBytes, passPhrase)
 		if err != nil {
 			return nil, err
-		} else {
-			return signerwithpassphrase, err
 		}
-	} else {
-		return signerwithoutpassphrase, err
+
+		return signerwithpassphrase, err
 	}
+
+	return signerwithoutpassphrase, err
 }
 
 func sshAgent() ssh.AuthMethod {

--- a/cutil/reconciler.go
+++ b/cutil/reconciler.go
@@ -24,9 +24,9 @@ import (
 
 func GetReconciler(c *cluster.Cluster) (cloud.Reconciler, error) {
 	switch c.Cloud {
-	case cluster.Cloud_Amazon:
+	case cluster.CloudAmazon:
 		return amazon.NewReconciler(c), nil
-	case cluster.Cloud_DigitalOcean:
+	case cluster.CloudDigitalOcean:
 		return digitalocean.NewReconciler(c), nil
 	default:
 		return nil, fmt.Errorf("Invalid cloud type: %s", c.Cloud)

--- a/cutil/scp/scp.go
+++ b/cutil/scp/scp.go
@@ -111,12 +111,12 @@ func GetSigner(pemBytes []byte) (ssh.Signer, error) {
 		signerwithpassphrase, err := ssh.ParsePrivateKeyWithPassphrase(pemBytes, passPhrase)
 		if err != nil {
 			return nil, err
-		} else {
-			return signerwithpassphrase, err
 		}
-	} else {
-		return signerwithoutpassphrase, err
+
+		return signerwithpassphrase, err
 	}
+
+	return signerwithoutpassphrase, err
 }
 
 func sshAgent() ssh.AuthMethod {

--- a/examples/amazon/basiccluster.go
+++ b/examples/amazon/basiccluster.go
@@ -61,17 +61,17 @@ func main() {
 func getCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
-		Cloud:    cluster.Cloud_Amazon,
+		Cloud:    cluster.CloudAmazon,
 		Location: "us-west-2",
-		Ssh: &cluster.Ssh{
+		SSH: &cluster.SSH{
 			PublicKeyPath: "~/.ssh/id_rsa.pub",
 			User:          "ubuntu",
 		},
-		KubernetesApi: &cluster.KubernetesApi{
+		KubernetesAPI: &cluster.KubernetesAPI{
 			Port: "443",
 		},
 		Network: &cluster.Network{
-			Type: cluster.NetworkType_Public,
+			Type: cluster.NetworkTypePublic,
 			CIDR: "10.0.0.0/16",
 		},
 		Values: &cluster.Values{
@@ -81,7 +81,7 @@ func getCluster(name string) *cluster.Cluster {
 		},
 		ServerPools: []*cluster.ServerPool{
 			{
-				Type:            cluster.ServerPoolType_Master,
+				Type:            cluster.ServerPoolTypeMaster,
 				Name:            fmt.Sprintf("%s.master", name),
 				MaxCount:        1,
 				MinCount:        1,
@@ -117,7 +117,7 @@ func getCluster(name string) *cluster.Cluster {
 				},
 			},
 			{
-				Type:            cluster.ServerPoolType_Node,
+				Type:            cluster.ServerPoolTypeNode,
 				Name:            fmt.Sprintf("%s.node", name),
 				MaxCount:        1,
 				MinCount:        1,

--- a/examples/digitalocean/basiccluster.go
+++ b/examples/digitalocean/basiccluster.go
@@ -61,13 +61,13 @@ func main() {
 func getCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
-		Cloud:    cluster.Cloud_DigitalOcean,
+		Cloud:    cluster.CloudDigitalOcean,
 		Location: "sfo2",
-		Ssh: &cluster.Ssh{
+		SSH: &cluster.SSH{
 			PublicKeyPath: "~/.ssh/id_rsa.pub",
 			User:          "root",
 		},
-		KubernetesApi: &cluster.KubernetesApi{
+		KubernetesAPI: &cluster.KubernetesAPI{
 			Port: "443",
 		},
 		Values: &cluster.Values{
@@ -77,7 +77,7 @@ func getCluster(name string) *cluster.Cluster {
 		},
 		ServerPools: []*cluster.ServerPool{
 			{
-				Type:            cluster.ServerPoolType_Master,
+				Type:            cluster.ServerPoolTypeMaster,
 				Name:            fmt.Sprintf("%s-master", name),
 				MaxCount:        1,
 				Image:           "ubuntu-16-04-x64",
@@ -85,7 +85,7 @@ func getCluster(name string) *cluster.Cluster {
 				BootstrapScript: "digitalocean_k8s_ubuntu_16.04_master.sh",
 			},
 			{
-				Type:            cluster.ServerPoolType_Node,
+				Type:            cluster.ServerPoolTypeNode,
 				Name:            fmt.Sprintf("%s-node", name),
 				MaxCount:        3,
 				Image:           "ubuntu-16-04-x64",

--- a/profiles/simpleamazon.go
+++ b/profiles/simpleamazon.go
@@ -23,17 +23,17 @@ import (
 func NewSimpleAmazonCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
-		Cloud:    cluster.Cloud_Amazon,
+		Cloud:    cluster.CloudAmazon,
 		Location: "us-west-2",
-		Ssh: &cluster.Ssh{
+		SSH: &cluster.SSH{
 			PublicKeyPath: "~/.ssh/id_rsa.pub",
 			User:          "ubuntu",
 		},
-		KubernetesApi: &cluster.KubernetesApi{
+		KubernetesAPI: &cluster.KubernetesAPI{
 			Port: "443",
 		},
 		Network: &cluster.Network{
-			Type: cluster.NetworkType_Public,
+			Type: cluster.NetworkTypePublic,
 			CIDR: "10.0.0.0/16",
 		},
 		Values: &cluster.Values{
@@ -43,7 +43,7 @@ func NewSimpleAmazonCluster(name string) *cluster.Cluster {
 		},
 		ServerPools: []*cluster.ServerPool{
 			{
-				Type:            cluster.ServerPoolType_Master,
+				Type:            cluster.ServerPoolTypeMaster,
 				Name:            fmt.Sprintf("%s.master", name),
 				MaxCount:        1,
 				MinCount:        1,
@@ -79,7 +79,7 @@ func NewSimpleAmazonCluster(name string) *cluster.Cluster {
 				},
 			},
 			{
-				Type:            cluster.ServerPoolType_Node,
+				Type:            cluster.ServerPoolTypeNode,
 				Name:            fmt.Sprintf("%s.node", name),
 				MaxCount:        1,
 				MinCount:        1,

--- a/profiles/simpledigitalocean.go
+++ b/profiles/simpledigitalocean.go
@@ -23,13 +23,13 @@ import (
 func NewSimpleDigitalOceanCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
-		Cloud:    cluster.Cloud_DigitalOcean,
+		Cloud:    cluster.CloudDigitalOcean,
 		Location: "sfo2",
-		Ssh: &cluster.Ssh{
+		SSH: &cluster.SSH{
 			PublicKeyPath: "~/.ssh/id_rsa.pub",
 			User:          "root",
 		},
-		KubernetesApi: &cluster.KubernetesApi{
+		KubernetesAPI: &cluster.KubernetesAPI{
 			Port: "443",
 		},
 		Values: &cluster.Values{
@@ -39,7 +39,7 @@ func NewSimpleDigitalOceanCluster(name string) *cluster.Cluster {
 		},
 		ServerPools: []*cluster.ServerPool{
 			{
-				Type:            cluster.ServerPoolType_Master,
+				Type:            cluster.ServerPoolTypeMaster,
 				Name:            fmt.Sprintf("%s-master", name),
 				MaxCount:        1,
 				Image:           "ubuntu-16-04-x64",
@@ -47,7 +47,7 @@ func NewSimpleDigitalOceanCluster(name string) *cluster.Cluster {
 				BootstrapScript: "digitalocean_k8s_ubuntu_16.04_master.sh",
 			},
 			{
-				Type:            cluster.ServerPoolType_Node,
+				Type:            cluster.ServerPoolTypeNode,
 				Name:            fmt.Sprintf("%s-node", name),
 				MaxCount:        1,
 				Image:           "ubuntu-16-04-x64",

--- a/state/fs/impl.go
+++ b/state/fs/impl.go
@@ -81,7 +81,7 @@ func (fs *FileSystemStore) read(relativePath string) ([]byte, error) {
 
 func (fs *FileSystemStore) Commit(c *cluster.Cluster) error {
 	if c == nil {
-		return fmt.Errorf("Nil cluster spec!")
+		return fmt.Errorf("Nil cluster spec")
 	}
 	bytes, err := yaml.Marshal(c)
 	if err != nil {
@@ -115,16 +115,16 @@ func (fs *FileSystemStore) GetCluster() (*cluster.Cluster, error) {
 
 func (fs *FileSystemStore) List() ([]string, error) {
 
-	var state_list []string
+	var stateList []string
 
 	files, err := ioutil.ReadDir(fs.options.BasePath)
 	if err != nil {
-		return state_list, err
+		return stateList, err
 	}
 
 	for _, file := range files {
-		state_list = append(state_list, file.Name())
+		stateList = append(stateList, file.Name())
 	}
 
-	return state_list, nil
+	return stateList, nil
 }

--- a/test/amazon/ubuntu_cluster_test.go
+++ b/test/amazon/ubuntu_cluster_test.go
@@ -63,17 +63,17 @@ func TestMain(m *testing.M) {
 }
 
 const (
-	ApiSleepSeconds   = 5
-	ApiSocketAttempts = 40
+	APISleepSeconds   = 5
+	APISocketAttempts = 40
 )
 
 func TestApiListen(t *testing.T) {
 	success := false
-	for i := 0; i < ApiSocketAttempts; i++ {
-		_, err := network.AssertTcpSocketAcceptsConnection(fmt.Sprintf("%s:%s", testCluster.KubernetesApi.Endpoint, testCluster.KubernetesApi.Port), "opening a new socket connection against the Kubernetes API")
+	for i := 0; i < APISocketAttempts; i++ {
+		_, err := network.AssertTcpSocketAcceptsConnection(fmt.Sprintf("%s:%s", testCluster.KubernetesAPI.Endpoint, testCluster.KubernetesAPI.Port), "opening a new socket connection against the Kubernetes API")
 		if err != nil {
 			logger.Info("Attempting to open a socket to the Kubernetes API: %v...\n", err)
-			time.Sleep(time.Duration(ApiSleepSeconds) * time.Second)
+			time.Sleep(time.Duration(APISleepSeconds) * time.Second)
 			continue
 		}
 		success = true

--- a/test/digitalocean/ubuntu_cluster_test.go
+++ b/test/digitalocean/ubuntu_cluster_test.go
@@ -63,17 +63,17 @@ func TestMain(m *testing.M) {
 }
 
 const (
-	ApiSleepSeconds   = 5
-	ApiSocketAttempts = 40
+	APISleepSeconds   = 5
+	APISocketAttempts = 40
 )
 
 func TestApiListen(t *testing.T) {
 	success := false
-	for i := 0; i < ApiSocketAttempts; i++ {
-		_, err := network.AssertTcpSocketAcceptsConnection(fmt.Sprintf("%s:%s", testCluster.KubernetesApi.Endpoint, testCluster.KubernetesApi.Port), "opening a new socket connection against the Kubernetes API")
+	for i := 0; i < APISocketAttempts; i++ {
+		_, err := network.AssertTcpSocketAcceptsConnection(fmt.Sprintf("%s:%s", testCluster.KubernetesAPI.Endpoint, testCluster.KubernetesAPI.Port), "opening a new socket connection against the Kubernetes API")
 		if err != nil {
 			logger.Info("Attempting to open a socket to the Kubernetes API: %v...\n", err)
-			time.Sleep(time.Duration(ApiSleepSeconds) * time.Second)
+			time.Sleep(time.Duration(APISleepSeconds) * time.Second)
 			continue
 		}
 		success = true


### PR DESCRIPTION
There are still 196 warnings after this. But these are all just missing comments. 