### PR TITLE
ifconfig is deprecated and should be avoided

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Mario Mazo <mario.mazo@affinitas.de>
 Marko Mudrinić <mudrinic.mare@gmail.com>
 Martin Etmajer <martin@etmajer.com>
 Michael Hausenblas <michael.hausenblas@gmail.com>
+Michael Zamot <michael@zamot.io>
 Paul Czarkowski <username.taken@gmail.com>
 Peter Smeets <p.e.smeets@gmail.com>
 Ted Wood <ted@xy0.org>

--- a/bootstrap/amazon_k8s_ubuntu_16.04_master.sh
+++ b/bootstrap/amazon_k8s_ubuntu_16.04_master.sh
@@ -32,7 +32,7 @@ systemctl enable docker
 systemctl start docker
 
 PUBLICIP=$(ec2metadata --public-ipv4 | cut -d " " -f 2)
-PRIVATEIP=$(ifconfig | grep -A 1 eth0 | grep inet | cut -d ":" -f 2 | cut -d " " -f 1 | xargs)
+PRIVATEIP=$(ip addr show dev eth0 | awk '/inet / {print $2}' | cut -d"/" -f1)
 
 kubeadm reset
 kubeadm init --apiserver-bind-port ${PORT} --token ${TOKEN}  --apiserver-advertise-address ${PUBLICIP} --apiserver-cert-extra-sans ${PUBLICIP} ${PRIVATEIP}

--- a/bootstrap/digitalocean_k8s_ubuntu_16.04_master.sh
+++ b/bootstrap/digitalocean_k8s_ubuntu_16.04_master.sh
@@ -33,7 +33,7 @@ apt-get install -y \
 systemctl enable docker
 systemctl start docker
 
-PRIVATEIP=$(ifconfig | grep -A 1 "tun0" | grep inet  | cut -d ":" -f 2 | cut -d " " -f 1)
+PRIVATEIP=$(ip addr show dev tun0 | awk '/inet / {print $2}' | cut -d"/" -f1)
 echo $PRIVATEIP > /tmp/.ip
 PUBLICIP=$(curl ifconfig.me)
 


### PR DESCRIPTION
Some Linux distributions have deprecated the use of ifconfig and route in favor of the software suite iproute2. The command ip should be used instead of ifconfig.