### PR TITLE
Makefile: Green text instead of black background

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,4 +129,4 @@ endif
 
 .PHONY: help
 help:  ## Show help messages for make targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[40m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Instead of setting a black background on the make commands (making them impossible to read without highlighting them), set the text color to be green.