### PR TITLE
Fixes make update-headers command on OSX

### DIFF
--- a/scripts/headers.sh
+++ b/scripts/headers.sh
@@ -30,27 +30,13 @@ read -r -d '' EXPECTED <<EOF
 // limitations under the License.
 EOF
 
-read -r -d '' LICENSE <<EOF
-// Copyright © 2017 The Kubicorn Authors\n//\n// Licensed under the Apache License, Version 2.0 (the "License");\n// you may not use this file except in compliance with the License.\n// You may obtain a copy of the License at\n//\n//\ \ \ \ \ http://www.apache.org/licenses/LICENSE-2.0\n//\n// Unless required by applicable law or agreed to in writing, software\n// distributed under the License is distributed on an "AS IS" BASIS,\n// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n// See the License for the specific language governing permissions and\n// limitations under the License.
-EOF
-
-SED_I="sed -i"
-GOHOSTOS=$(go env GOHOSTOS)
-
-if [ "$GOHOSTOS" == "darwin" ]; then
-  SED_I="sed -i ''"
-fi
-
 FILES=$(find . -name "*.go" -not -path "./vendor/*")
-echo ${SED_I}
 for FILE in $FILES; do
 	if [ "$FILE" == "./bootstrap/bootstrap.go" ]; then
             continue
         fi
-
         CONTENT=$(head -n 13 $FILE)
         if [ "$CONTENT" != "$EXPECTED" ]; then
-		ESCAPED=$(echo $LICENSE | awk '{printf "%s\\n", $0}')
-		${SED_I} "1s|^|${ESCAPED}\n|" $FILE
+		echo -e "$EXPECTED\n\n$(cat $FILE)" > $FILE
         fi
 done


### PR DESCRIPTION
Removed sed command on OSX, replaced with echo and simplified logic.

Running sed command on OSX doesn't add the header in correct format. I have removed the logic for checking OS, using sed and replaced with echo. Verified on OSX and Linux.