### PR TITLE
Minor log message change - removeing "subnet"

### DIFF
--- a/cloud/amazon/resources/keypair.go
+++ b/cloud/amazon/resources/keypair.go
@@ -80,7 +80,7 @@ func (r *KeyPair) Actual(known *cluster.Cluster) (cloud.Resource, error) {
 func (r *KeyPair) Expected(known *cluster.Cluster) (cloud.Resource, error) {
 	logger.Debug("keypair.Expected")
 	if r.CachedExpected != nil {
-		logger.Debug("Using keypair subnet [expected]")
+		logger.Debug("Using keypair [expected]")
 		return r.CachedExpected, nil
 	}
 	expected := &KeyPair{


### PR DESCRIPTION
Minor message change - removed subnet from the log message - and a question.

I have found this while investigating a `potential ???` issue and will track this one below in a different issue and sent a fix in case it's valid - it's just a heads un and very much interested in your opinion. In case a user has changed/regenerated his local keys, and a cluster is created with the new key pair but same name, the old keypairs are still available on the AWS side. The cluster is created (with the same name - in my case by a CI system) but the end user/test suite wont be able to SSH into it. Obliviously this is up to interpretation and not a likely scenario - just wandering whether it makes sense to check or log whether the user's key has changed and the public fingerprints are different. 

Thank you.