### PR TITLE
cmd: fix name bash completions

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -66,8 +66,6 @@ func init() {
 	applyCmd.Flags().StringVarP(&ao.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	applyCmd.Flags().StringVarP(&ao.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 
-	//flagApplyAnnotations(applyCmd, "name", "__kubicorn_parse_list")
-
 	RootCmd.AddCommand(applyCmd)
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -68,7 +68,6 @@ func init() {
 	createCmd.Flags().StringVarP(&co.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	createCmd.Flags().StringVarP(&co.Profile, "profile", "p", strEnvDef("KUBICORN_PROFILE", "azure"), "The cluster profile to use")
 
-	//flagApplyAnnotations(createCmd, "name", "__kubicorn_parse_list")
 	flagApplyAnnotations(createCmd, "profile", "__kubicorn_parse_profiles")
 
 	RootCmd.AddCommand(createCmd)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -70,8 +70,6 @@ func init() {
 	deleteCmd.Flags().StringVarP(&do.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	deleteCmd.Flags().BoolVarP(&do.Purge, "purge", "p", false, "Remove the API model from the state store after the resources are deleted.")
 
-	//flagApplyAnnotations(deleteCmd, "name", "__kubicorn_parse_list")
-
 	RootCmd.AddCommand(deleteCmd)
 }
 

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -63,8 +63,6 @@ func init() {
 	getConfigCmd.Flags().StringVarP(&cro.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	getConfigCmd.Flags().StringVarP(&cro.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 
-	//flagApplyAnnotations(getConfigCmd, "name", "__kubicorn_parse_list")
-
 	RootCmd.AddCommand(getConfigCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,16 @@ __kubicorn_parse_profiles()
         COMPREPLY=( $( compgen -W "${kubicorn_out[*]}" -- "$cur" ) )
     fi
 }
+__custom_func() {
+    case ${last_command} in
+        kubicorn_apply | kubicorn_create | kubicorn_delete | kubicorn_getconfig)
+            __kubicorn_parse_list
+            return
+            ;;
+        *)
+            ;;
+    esac
+}
 `
 )
 


### PR DESCRIPTION
This PR fixes Shell completions for cluster names, as `-n` flag got removed back in #265 