### PR TITLE
Kubicorn #286 - Use unique name (within VPC/region) for a security group

### DIFF
--- a/cutil/uuid/uuid.go
+++ b/cutil/uuid/uuid.go
@@ -1,0 +1,36 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uuid
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// Generates a time ordered UUID. Top 32b are timestamp bottom 96b are random.
+func TimeOrderedUUID() string {
+	unixTime := uint32(time.Now().UTC().Unix())
+	randomPart1 := rand.Uint32()
+	randomPart2 := rand.Uint32()
+	randomPart3 := rand.Uint32()
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%04x%08x",
+		unixTime,
+		uint16(randomPart1>>16),
+		uint16(randomPart1&0xffff),
+		uint16(randomPart2>>16),
+		uint16(randomPart2&0xffff),
+		randomPart3)
+}

--- a/profiles/centosamazon.go
+++ b/profiles/centosamazon.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/kubeadm"
+	"github.com/kris-nova/kubicorn/cutil/uuid"
 )
 
 func NewCentosAmazonCluster(name string) *cluster.Cluster {
@@ -64,7 +65,7 @@ func NewCentosAmazonCluster(name string) *cluster.Cluster {
 
 				Firewalls: []*cluster.Firewall{
 					{
-						Name: fmt.Sprintf("%s.master-external", name),
+						Name: fmt.Sprintf("%s.master-external-%s", name, uuid.TimeOrderedUUID()),
 						IngressRules: []*cluster.IngressRule{
 							{
 								IngressFromPort: "22",
@@ -101,7 +102,7 @@ func NewCentosAmazonCluster(name string) *cluster.Cluster {
 				},
 				Firewalls: []*cluster.Firewall{
 					{
-						Name: fmt.Sprintf("%s.node-external", name),
+						Name: fmt.Sprintf("%s.node-external-%s", name, uuid.TimeOrderedUUID()),
 						IngressRules: []*cluster.IngressRule{
 							{
 								IngressFromPort: "22",

--- a/profiles/ubuntuamazon.go
+++ b/profiles/ubuntuamazon.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/kubeadm"
+	"github.com/kris-nova/kubicorn/cutil/uuid"
 )
 
 // NewUbuntuAmazonCluster creates a simple Ubuntu Amazon cluster
@@ -65,7 +66,7 @@ func NewUbuntuAmazonCluster(name string) *cluster.Cluster {
 
 				Firewalls: []*cluster.Firewall{
 					{
-						Name: fmt.Sprintf("%s.master-external", name),
+						Name: fmt.Sprintf("%s.master-external-%s", name, uuid.TimeOrderedUUID()),
 						IngressRules: []*cluster.IngressRule{
 							{
 								IngressFromPort: "22",
@@ -102,7 +103,7 @@ func NewUbuntuAmazonCluster(name string) *cluster.Cluster {
 				},
 				Firewalls: []*cluster.Firewall{
 					{
-						Name: fmt.Sprintf("%s.node-external", name),
+						Name: fmt.Sprintf("%s.node-external-%s", name, uuid.TimeOrderedUUID()),
 						IngressRules: []*cluster.IngressRule{
 							{
 								IngressFromPort: "22",


### PR DESCRIPTION
This PR is related to #286 - a time ordered UUID generator is added and the unique name is applied when specifying the name of the security group in the default clusters. 

Ideally I wanted to have this included in the `securitygroup.go` - however while working on cluster update found this causes different issues during reconcile and state management. Once the new refactor is finished and also a different cluster update PR is merged we can return to this - for now this leaves the uniqueness generation (as AWS does) to the end user's discretion, and serves as an example in the cluster templates, and providing a UUID generator.