### PR TITLE
do: fix ssh key creation bug

### DIFF
--- a/cloud/digitalocean/droplet/resources/ssh.go
+++ b/cloud/digitalocean/droplet/resources/ssh.go
@@ -79,6 +79,8 @@ func (r *SSH) Actual(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resour
 		}
 		if !found {
 			newResource.PublicKeyPath = immutable.SSH.PublicKeyPath
+			newResource.PublicKeyFingerprint = immutable.SSH.PublicKeyFingerprint
+			newResource.PublicKeyData = string(immutable.SSH.PublicKeyData)
 			newResource.User = immutable.SSH.User
 			newResource.CloudID = immutable.SSH.Identifier
 		}
@@ -111,7 +113,7 @@ func (r *SSH) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster)
 	if err != nil {
 		return nil, nil, err
 	}
-	if isEqual {
+	if isEqual && actual.(*SSH).Shared.CloudID != "" {
 		return immutable, applyResource, nil
 	}
 	request := &godo.KeyCreateRequest{


### PR DESCRIPTION
If SSH key doesn't exist in DO account, it will not be created and instead, the following error will be returned:
```
2017-08-18T21:54:11+02:00 [✖]  Error during apply of atomic reconciler, attempting clawback: strconv.Atoi: parsing "": invalid syntax
2017-08-18T21:54:11+02:00 [!]
2017-08-18T21:54:11+02:00 [!]  Attempting to backtrack and cleanup created resources.
2017-08-18T21:54:11+02:00 [!]
2017-08-18T21:54:11+02:00 [▶]  ssh.Delete
2017-08-18T21:54:11+02:00 [▶]  ssh.Render
2017-08-18T21:54:11+02:00 [✖]  Unable to commit state store: Nil cluster spec
```

This PR should fix this behavior - i.e. keys will be created normally.