### PR TITLE
Added cloudid option

### DIFF
--- a/apis/cluster/cluster.go
+++ b/apis/cluster/cluster.go
@@ -29,15 +29,15 @@ const (
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Name          string         `json:"name,omitempty"`
-	CloudId       string         `json:"cloudId,omitempty"`
-	ServerPools   []*ServerPool  `json:"serverPools,omitempty"`
-	Cloud         string         `json:"cloud,omitempty"`
-	Location      string         `json:"location,omitempty"`
-	SSH           *SSH           `json:"SSH,omitempty"`
-	Network       *Network       `json:"network,omitempty"`
-	Values        *Values        `json:"values,omitempty"`
-	KubernetesAPI *KubernetesAPI `json:"kubernetesAPI,omitempty"`
+	Name              string         `json:"name,omitempty"`
+	CloudId           string         `json:"cloudId,omitempty"`
+	ServerPools       []*ServerPool  `json:"serverPools,omitempty"`
+	Cloud             string         `json:"cloud,omitempty"`
+	Location          string         `json:"location,omitempty"`
+	SSH               *SSH           `json:"SSH,omitempty"`
+	Network           *Network       `json:"network,omitempty"`
+	Values            *Values        `json:"values,omitempty"`
+	KubernetesAPI     *KubernetesAPI `json:"kubernetesAPI,omitempty"`
 }
 
 func NewCluster(name string) *Cluster {

--- a/apis/cluster/cluster.go
+++ b/apis/cluster/cluster.go
@@ -29,14 +29,15 @@ const (
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Name              string         `json:"name,omitempty"`
-	ServerPools       []*ServerPool  `json:"serverPools,omitempty"`
-	Cloud             string         `json:"cloud,omitempty"`
-	Location          string         `json:"location,omitempty"`
-	SSH               *SSH           `json:"SSH,omitempty"`
-	Network           *Network       `json:"network,omitempty"`
-	Values            *Values        `json:"values,omitempty"`
-	KubernetesAPI     *KubernetesAPI `json:"kubernetesAPI,omitempty"`
+	Name          string         `json:"name,omitempty"`
+	CloudId       string         `json:"cloudId,omitempty"`
+	ServerPools   []*ServerPool  `json:"serverPools,omitempty"`
+	Cloud         string         `json:"cloud,omitempty"`
+	Location      string         `json:"location,omitempty"`
+	SSH           *SSH           `json:"SSH,omitempty"`
+	Network       *Network       `json:"network,omitempty"`
+	Values        *Values        `json:"values,omitempty"`
+	KubernetesAPI *KubernetesAPI `json:"kubernetesAPI,omitempty"`
 }
 
 func NewCluster(name string) *Cluster {

--- a/cloud/google/compute/resources/compute_test.go
+++ b/cloud/google/compute/resources/compute_test.go
@@ -58,7 +58,7 @@ func TestExpectedHappy(t *testing.T) {
 		{"Shared.cloudId", resource.(*Instance).Shared.CloudID, "ClusterPool1"},
 		{"Size", resource.(*Instance).Size, "5"},
 		{"Label Amount", len(resource.(*Instance).Labels), 1},
-		{"Label group", resource.(*Instance).Labels["group"], "SharedName"},
+		{"Label group", resource.(*Instance).Labels["group"], "sharedname"},
 		{"Location", resource.(*Instance).Location, "Location-us"},
 		{"Image", resource.(*Instance).Image, "server-os-image"},
 		{"Count", resource.(*Instance).Count, 5},

--- a/cloud/google/compute/resources/compute_test.go
+++ b/cloud/google/compute/resources/compute_test.go
@@ -37,7 +37,8 @@ func TestExpectedHappy(t *testing.T) {
 	}
 
 	knownCluster := &cluster.Cluster{
-		Name: "ClusterName",
+		Name:    "ClusterName",
+		CloudId: "test-123",
 		SSH: &cluster.SSH{
 			PublicKeyFingerprint: "fingerprint",
 		},

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -39,7 +39,7 @@ type CreateOptions struct {
 var co = &CreateOptions{}
 
 var createCmd = &cobra.Command{
-	Use:   "create [NAME] [-p|--profile PROFILENAME] [-ci|--cloudid CLOUDID]",
+	Use:   "create [NAME] [-p|--profile PROFILENAME] [-c|--cloudid CLOUDID]",
 	Short: "Create a Kubicorn API model from a profile",
 	Long: `Use this command to create a Kubicorn API model in a defined state store.
 
@@ -137,7 +137,7 @@ func RunCreate(options *CreateOptions) error {
 	}
 
 	if newCluster.Cloud == cluster.CloudGoogle && options.CloudId == "" {
-		return fmt.Errorf("--cloudid is required for google cloud.")
+		return fmt.Errorf("CloudID is required for google cloud.")
 	}
 	newCluster.CloudId = options.CloudId
 	// Expand state store path

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -39,7 +39,7 @@ type CreateOptions struct {
 var co = &CreateOptions{}
 
 var createCmd = &cobra.Command{
-	Use:   "create [NAME] [-p|--profile PROFILENAME]",
+	Use:   "create [NAME] [-p|--profile PROFILENAME] [-ci|--cloudid CLOUDID]",
 	Short: "Create a Kubicorn API model from a profile",
 	Long: `Use this command to create a Kubicorn API model in a defined state store.
 
@@ -69,8 +69,10 @@ func init() {
 	createCmd.Flags().StringVarP(&co.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	createCmd.Flags().StringVarP(&co.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	createCmd.Flags().StringVarP(&co.Profile, "profile", "p", strEnvDef("KUBICORN_PROFILE", "azure"), "The cluster profile to use")
+	createCmd.Flags().StringVarP(&co.CloudId, "cloudid", "c", strEnvDef("KUBICORN_CLOUDID", ""), "The cloud id")
 
 	flagApplyAnnotations(createCmd, "profile", "__kubicorn_parse_profiles")
+	flagApplyAnnotations(createCmd, "cloudid", "__kubicorn_parse_cloudid")
 
 	RootCmd.SetUsageTemplate(usageTemplate)
 	RootCmd.AddCommand(createCmd)
@@ -134,6 +136,7 @@ func RunCreate(options *CreateOptions) error {
 		return fmt.Errorf("Invalid profile [%s]", options.Profile)
 	}
 
+	cluster.CloudId = options.CloudId
 	// Expand state store path
 	// Todo (@kris-nova) please pull this into a filepath package or something
 	options.StateStorePath = expandPath(options.StateStorePath)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,7 @@ type Options struct {
 	StateStore     string
 	StateStorePath string
 	Name           string
+	CloudId        string
 }
 
 func Execute() {

--- a/cutil/defaults/defaults.go
+++ b/cutil/defaults/defaults.go
@@ -19,6 +19,7 @@ import "github.com/kris-nova/kubicorn/apis/cluster"
 func NewClusterDefaults(base *cluster.Cluster) *cluster.Cluster {
 	new := &cluster.Cluster{
 		Name:          base.Name,
+		CloudId:       base.CloudId,
 		Cloud:         base.Cloud,
 		Location:      base.Location,
 		Network:       base.Network,

--- a/profiles/ubuntugooglecompute.go
+++ b/profiles/ubuntugooglecompute.go
@@ -25,6 +25,7 @@ import (
 func NewUbuntuGoogleComputeCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
+		CloudId:  "example-id",
 		Cloud:    cluster.CloudGoogle,
 		Location: "us-central1-a",
 		SSH: &cluster.SSH{


### PR DESCRIPTION
For GCE atm you needed to have the kubicorn name and the project-id be the same. This PR adds a parameter cloudid to the create command to be able to set the project-id differently then the kubicorn name. It also requires the cloudid parameter but only for GCE.

Closes #291 