### PR TITLE
AWS Spot price support 

### DIFF
--- a/apis/cluster/serverpool.go
+++ b/apis/cluster/serverpool.go
@@ -34,6 +34,7 @@ type ServerPool struct {
 	Name              string      `json:"name,omitempty"`
 	Image             string      `json:"image,omitempty"`
 	Size              string      `json:"size,omitempty"`
+	SpotPrice         string      `json:"spotPrice,omitempty"`
 	BootstrapScripts  []string    `json:"bootstrapScripts,omitempty"`
 	Subnets           []*Subnet   `json:"subnets,omitempty"`
 	Firewalls         []*Firewall `json:"firewalls,omitempty"`


### PR DESCRIPTION
This feature is adding the option to create the cluster using AWS spot instances. For `node` type instances (`cluster.ServerPoolTypeNode`) the launch configuration is created with a spot request and submitted. 

This feature is a potential pre-requisite for #321 in order to be able to run e2e nightly integration tests at a considerable cheaper price. 

There are several outcomes (handled): 

- Spot price is fulfilled and the instances are launched with the desired price
- Spot price can't be fulfilled: `Placed Spot instance request. Status Reason: Placed Spot instance request: sir-m6pi6f7p. Waiting for instance(s)`
- Spot price is not supported for the given instance type: `Placing Spot instance request. Status Reason: Value (t2.medium) for parameter instanceType is invalid. 't2.medium' is an unsupported instance type. Placing Spot instance request failed.`
- If a cluster can't be created and the end user doesn't want to wait any longer, the cluster can be deleted as usual and the bid is removed

**Limitations** 
```
The following instance types are not supported for Spot by AWS:

T2
HS1
```

Suggesting to use the `on-demand` instance price as the `spot-price` - this almost guarantees that the spot request is fulfilled but the instance is launchd with the current market spot bid price but never raises above the `on-demand` price. 

**Future improvements** 

- Add spot fleet support
- Add GCE `preemptible` VM support



