### PR TITLE
feature allow override of cluster settings

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -65,7 +65,7 @@ The apply will run once, and ultimately time out if something goes wrong.`,
 func init() {
 	applyCmd.Flags().StringVarP(&ao.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	applyCmd.Flags().StringVarP(&ao.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
-
+	applyCmd.Flags().StringVarP(&ao.Override, "override", "o", strEnvDef("KUBICORN_OVERRIDE", ""), "override cluster setting")
 	RootCmd.AddCommand(applyCmd)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ type Options struct {
 	StateStorePath string
 	Name           string
 	CloudId        string
+	Override			 string
 }
 
 func Execute() {


### PR DESCRIPTION
create `--override` cli option for create/apply commands to
allow user to override a cluster setting.

Addresses #324