### PR TITLE
Removed author box; fixed social media links

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,3 +43,5 @@ collections:
     output: true
     layout: documentation
 #    permalink: /:collection/:name
+
+twitter_username: kubicornk8s

--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -24,7 +24,7 @@ layout: default
 -->
 
 <div class="row">
-    <div class="col-sm-4">
+    <div class="col-sm-4 mb-5">
         <h5 class="mb-3">Documentation</h5>
         {% assign docs = site.documentation | sort: 'title' %}
 
@@ -39,40 +39,40 @@ layout: default
         </div>
 
         <div class="sidebar mb-2 mt-4">
-                <h6 class="mb-3">AWS</h6>
-                {% for cookie in docs %} {% if cookie.doctype == "aws" %}
+            <h6 class="mb-3">AWS</h6>
+            {% for cookie in docs %} {% if cookie.doctype == "aws" %}
+            <a href="{{ cookie.url | relative_url }}">
+                <p class="mb-2">{{ cookie.title }}</p>
+            </a>
+            {% endif %} {% endfor %}
+        </div>
+
+        <div class="sidebar mb-2 mt-4">
+            <h6 class="mb-3">Azure</h6>
+            {% for cookie in docs %} {% if cookie.doctype == "azure" %}
+            <a href="{{ cookie.url | relative_url }}">
+                <p class="mb-2">{{ cookie.title }}</p>
+            </a>
+            {% endif %} {% endfor %}
+        </div>
+
+        <div class="sidebar mb-2 mt-4">
+                <h6 class="mb-3">Digital Ocean</h6>
+                {% for cookie in docs %} {% if cookie.doctype == "do" %}
                 <a href="{{ cookie.url | relative_url }}">
                     <p class="mb-2">{{ cookie.title }}</p>
                 </a>
                 {% endif %} {% endfor %}
             </div>
 
-            <div class="sidebar mb-2 mt-4">
-                    <h6 class="mb-3">Azure</h6>
-                    {% for cookie in docs %} {% if cookie.doctype == "azure" %}
-                    <a href="{{ cookie.url | relative_url }}">
-                        <p class="mb-2">{{ cookie.title }}</p>
-                    </a>
-                    {% endif %} {% endfor %}
-                </div>
-
-                <div class="sidebar mb-2 mt-4">
-                        <h6 class="mb-3">Digital Ocean</h6>
-                        {% for cookie in docs %} {% if cookie.doctype == "do" %}
-                        <a href="{{ cookie.url | relative_url }}">
-                            <p class="mb-2">{{ cookie.title }}</p>
-                        </a>
-                        {% endif %} {% endfor %}
-                    </div>
-
-                    <div class="sidebar mb-2 mt-4">
-                            <h6 class="mb-3">Google</h6>
-                            {% for cookie in docs %} {% if cookie.doctype == "google" %}
-                            <a href="{{ cookie.url | relative_url }}">
-                                <p class="mb-2">{{ cookie.title }}</p>
-                            </a>
-                            {% endif %} {% endfor %}
-                        </div>
+        <div class="sidebar mb-2 mt-4">
+                <h6 class="mb-3">Google</h6>
+                {% for cookie in docs %} {% if cookie.doctype == "google" %}
+                <a href="{{ cookie.url | relative_url }}">
+                    <p class="mb-2">{{ cookie.title }}</p>
+                </a>
+                {% endif %} {% endfor %}
+            </div>
 
     </div>
     <!-- 
@@ -88,50 +88,44 @@ layout: default
     888                               
     888                               
      -->
-    
-        <div class="col-sm-8">
-            <!-- <figure class="figure">
+    <div class="col-sm-8">
+        <!-- <figure class="figure">
                 <img src="https://placebear.com/g/1200/720" class="img-fluid" alt="Responsive image">
-    
+
                 <figcaption class="figure-caption text-left"><small><i>Image copyright 2007 ® Fancy Photographer</i></small></figcaption>
             </figure> -->
-            <h1>{{ page.title | escape }}</h1>
+        <h1>{{ page.title | escape }}</h1>
 
-
-
-            <p class="figure-caption text-left"><i>
+        <p class="figure-caption text-left"><i>
             {% assign date_format = site.minima.date_format | default: "%B %-d, %Y" %}
             {{ page.date | date: date_format }}</i></p>
-    
-            {{ content }}
-            
-    
-            <div class="social-media mt-4">
-                <h6 class="text-center">Share it:</h6>
+
+        {{ content }}
+
+        <div class="social-media mt-4 mb-5">
+            <h6 class="text-center">Share it:</h6>
             <p class="text-center" style="font-size: 2rem;">
-    <a href=""><i aria-hidden="true" class="fa fa-google-plus-square"></i></a> 
-    <a href=""><i aria-hidden="true" class="fa fa-facebook-square"></i></a> 
-    <a href=""><i aria-hidden="true" class="fa fa-twitter-square"></i></a> 
-    <a href=""><i aria-hidden="true" class="fa fa-instagram"></i></a> 
-    <a href=""><i aria-hidden="true" class="fa fa-linkedin-square"></i></a> 
-    <a href=""><i aria-hidden="true" class="fa fa-share-square-o"></i></a>
-    </p>
-    </div>
-    
-            <div class="row author-section mb-5">
-                <div class="col-4 col-lg-2">
-                      <img src="https://placebear.com/g/200/200" class="img-fluid" alt="Responsive image">
-                      </div>
-                    <div class="col align-self-center">
-            <a href=""><h6>Author J. Writer</h6></a>
-            <p><small>Dr. Writer is the bearer of many writings about bears, beers, and the second ammendment. As of late he's also been writing about kittins, the jerk.</small></p>
-    
-           </div></div>
-    
-    
-    
-    
-    
+                <a href="https://twitter.com/intent/tweet?text={{ page.title }}&url={{ site.url }}{{ page.url }}&via={{ site.twitter_username }}&related={{ site.twitter_username }}" rel="nofollow" target="_blank" title="Share on Twitter"><i aria-hidden="true" class="fa fa-twitter-square"></i></a>
+                <a href="https://facebook.com/sharer/sharer.php?u={{ site.url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Facebook"><i aria-hidden="true" class="fa fa-facebook-square"></i></a>
+                <a href="https://plus.google.com/share?url={{ site.url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Google+"><i aria-hidden="true" class="fa fa-google-plus-square"></i></a>
+                <a href="http://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ page.url }}&title={{ page.title }}" rel="nofollow" target="_blank" title="Share on LinkedIn"><i aria-hidden="true" class="fa fa-linkedin-square"></i></a>
+                <a href="http://www.reddit.com/submit?url={{ site.url }}{{ page.url }}&title={{ page.title }}" rel="nofollow" target="_blank" title="Share on Reddit"><i aria-hidden="true" class="fa fa-reddit-square"></i></a>
+            </p>
         </div>
+
+        <!-- <div class="row author-section mb-5">
+            <div class="col-4 col-lg-2">
+                <img src="https://placebear.com/g/200/200" class="img-fluid" alt="Responsive image">
+            </div>
+            <div class="col align-self-center">
+                <a href="">
+                    <h6>Author J. Writer</h6>
+                </a>
+                <p><small>Dr. Writer is the bearer of many writings about bears, beers, and the second ammendment. As of late he's also been writing about kittins, the jerk.</small></p>
+
+            </div>
+        </div> -->
+
     </div>
+</div>
     


### PR DESCRIPTION
This refers to the bottom part of documentation pages.

Closes #338. 

Someone please check that the g+ share link is working, I don't have a g+ account.