### PR TITLE
Externalize cloud specific settings from API 

### DIFF
--- a/apis/cluster/serverpool.go
+++ b/apis/cluster/serverpool.go
@@ -27,15 +27,19 @@ const (
 type ServerPool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Identifier        string      `json:"identifier,omitempty"`
-	MinCount          int         `json:"minCount,omitempty"`
-	MaxCount          int         `json:"maxCount,omitempty"`
-	Type              string      `json:"type,omitempty"`
-	Name              string      `json:"name,omitempty"`
-	Image             string      `json:"image,omitempty"`
-	Size              string      `json:"size,omitempty"`
-	SpotPrice         string      `json:"spotPrice,omitempty"`
-	BootstrapScripts  []string    `json:"bootstrapScripts,omitempty"`
-	Subnets           []*Subnet   `json:"subnets,omitempty"`
-	Firewalls         []*Firewall `json:"firewalls,omitempty"`
+	Identifier        string            `json:"identifier,omitempty"`
+	MinCount          int               `json:"minCount,omitempty"`
+	MaxCount          int               `json:"maxCount,omitempty"`
+	Type              string            `json:"type,omitempty"`
+	Name              string            `json:"name,omitempty"`
+	Image             string            `json:"image,omitempty"`
+	Size              string            `json:"size,omitempty"`
+	BootstrapScripts  []string          `json:"bootstrapScripts,omitempty"`
+	Subnets           []*Subnet         `json:"subnets,omitempty"`
+	Firewalls         []*Firewall       `json:"firewalls,omitempty"`
+	AwsConfiguration  *AwsConfiguration `json:"awsconfiguration,omitempty"`
+}
+
+type AwsConfiguration struct {
+	SpotPrice string `json:"spotPrice,omitempty"`
 }

--- a/cloud/amazon/public/resources/launchconfiguration.go
+++ b/cloud/amazon/public/resources/launchconfiguration.go
@@ -83,7 +83,7 @@ func (r *Lc) Actual(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resourc
 		newResource.Image = r.ServerPool.Image
 		newResource.InstanceType = r.ServerPool.Size
 		if r.ServerPool.Type == cluster.ServerPoolTypeNode {
-			newResource.SpotPrice = r.ServerPool.SpotPrice
+			newResource.SpotPrice = r.ServerPool.AwsConfiguration.SpotPrice
 		}
 	}
 	newResource.BootstrapScripts = r.ServerPool.BootstrapScripts
@@ -108,7 +108,7 @@ func (r *Lc) Expected(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resou
 		BootstrapScripts: r.ServerPool.BootstrapScripts,
 	}
 	if r.ServerPool.Type == cluster.ServerPoolTypeNode {
-		newResource.SpotPrice = r.ServerPool.SpotPrice
+		newResource.SpotPrice = r.ServerPool.AwsConfiguration.SpotPrice
 	}
 	newCluster := r.immutableRender(newResource, immutable)
 	return newCluster, newResource, nil

--- a/cutil/initapi/validate.go
+++ b/cutil/initapi/validate.go
@@ -38,7 +38,7 @@ func validateServerPoolMaxCountGreaterThan1(initCluster *cluster.Cluster) error 
 
 func validateSpotPriceOnlyForAwsCluster(initCluster *cluster.Cluster) error {
 	for _, p := range initCluster.ServerPools {
-		if p.SpotPrice != "" && initCluster.Cloud != cluster.CloudAmazon {
+		if p.AwsConfiguration != nil && p.AwsConfiguration.SpotPrice != "" && initCluster.Cloud != cluster.CloudAmazon {
 			return fmt.Errorf("Spot price provided for server pool %v can only be used with AWS", p.Name)
 		}
 	}

--- a/cutil/initapi/validate_test.go
+++ b/cutil/initapi/validate_test.go
@@ -95,8 +95,10 @@ func TestValidateSpotPriceOnlyForAwsClusterHappy(t *testing.T) {
 		Cloud: "amazon",
 		ServerPools: []*cluster.ServerPool{
 			{
-				Name:      "p",
-				SpotPrice: "1",
+				Name: "p",
+				AwsConfiguration: &cluster.AwsConfiguration{
+					SpotPrice: "1",
+				},
 			},
 		},
 	}
@@ -114,8 +116,10 @@ func TestValidateSpotPriceOnlyForAwsClusterSad(t *testing.T) {
 		Cloud: "azure",
 		ServerPools: []*cluster.ServerPool{
 			{
-				Name:      "p",
-				SpotPrice: "1",
+				Name: "p",
+				AwsConfiguration: &cluster.AwsConfiguration{
+					SpotPrice: "1",
+				},
 			},
 		},
 	}

--- a/test/amazon/centos_cluster_test.go
+++ b/test/amazon/centos_cluster_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 	//	}
 	//}()
 	test.InitRsaTravis()
-	testCluster = profiles.CentosAmazonCluster("centos-test")
+	testCluster = profiles.NewCentosAmazonCluster("centos-test")
 	testCluster, err = test.Create(testCluster)
 	if err != nil {
 		fmt.Printf("Unable to create Amazon test cluster: %v\n", err)

--- a/test/amazon/ubuntu_cluster_test.go
+++ b/test/amazon/ubuntu_cluster_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 	//	}
 	//}()
 	test.InitRsaTravis()
-	testCluster = profiles.NewSimpleAmazonCluster("ubuntu-test")
+	testCluster = profiles.NewUbuntuAmazonCluster("ubuntu-test")
 	testCluster, err = test.Create(testCluster)
 	if err != nil {
 		fmt.Printf("Unable to create Amazon test cluster: %v\n", err)


### PR DESCRIPTION
Re issue #354 the cloud provider settings are now externalized from the API (in this case the AWS `spot price` feature) and sets the way to move forward regarding cloud specific settings. 

@kris-nova and @MyDigitalLife - from a practical experience I believe that the cloud specific settings are better placed in the `ServerPool struct` instead of `Cluster struct` as we concluded in #354 - this makes room to apply different settings per hostgroups/serverpools - going forward with the spot price example instead of adding MasterSpotPrice/NodeSpotPrice or MasterIAM/NodeIAM it's better to just have SpotPrice and IAM in the serverpool and apply to the relevant pool. For example we don't run master with spot price but node only, whereas the two groups have two different IAM roles attached.

Please advise if you like it this way. 