### PR TITLE
Increase DO centos master memory to 2 GB

### DIFF
--- a/profiles/centosdigitalocean.go
+++ b/profiles/centosdigitalocean.go
@@ -45,7 +45,7 @@ func NewCentosDigitalOceanCluster(name string) *cluster.Cluster {
 				Name:     fmt.Sprintf("%s-master", name),
 				MaxCount: 1,
 				Image:    "centos-7-x64",
-				Size:     "1gb",
+				Size:     "2gb",
 				BootstrapScripts: []string{
 					"vpn/openvpnMaster-centos.sh",
 					"digitalocean_k8s_centos_7_master.sh",


### PR DESCRIPTION
The CentOS digital ocean cluster was failing to complete bootstrapping #393 , increasing memory on the master node to reduce memory pressure and allow the nodes to enter the ready state