### PR TITLE
Fix installation link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We believe that sharing is important, and encouraging our peers is even more imp
 $ go get github.com/kris-nova/kubicorn
 ``` 
 
-..or read the [Install Guide](docs/INSTALL.md).
+..or read the [Install Guide](http://kubicorn.io/documentation/install.html).
 
 ## How is Kubicorn different?
 


### PR DESCRIPTION
The README currently points to the old install guide under /docs, which has been moved/deprecated(?). I've fixed the link by pointing to the new kubicorn.io website.