### PR TITLE
Bugfix - Remove not needed channel drain

### DIFF
--- a/cutil/signals/signals.go
+++ b/cutil/signals/signals.go
@@ -70,9 +70,7 @@ func (h *Handler) GetState() int {
 }
 
 func (h *Handler) Reset() {
-	if !h.timer.Stop() {
-		<-h.timer.C
-	}
+	h.timer.Stop()
 }
 
 // Register starts handling signals.


### PR DESCRIPTION
The (unnecessary) channel drain caused Kubicorn to hang during cluster delete - see issue #411. This is a fix for the issue.

