### PR TITLE
Google network tags

### DIFF
--- a/cloud/google/compute/resources/instancegroup.go
+++ b/cloud/google/compute/resources/instancegroup.go
@@ -198,12 +198,20 @@ func (r *InstanceGroup) Apply(actual, expected cloud.Resource, immutable *cluste
 	}
 
 	tags := []string{}
-	if immutable.KubernetesAPI.Port == "443" {
-		tags = append(tags, "https-server")
+	if r.ServerPool.Type == cluster.ServerPoolTypeMaster {
+		if immutable.KubernetesAPI.Port == "443" {
+			tags = append(tags, "https-server")
+		}
+
+		if immutable.KubernetesAPI.Port == "80" {
+			tags = append(tags, "http-server")
+		}
+
+		tags = append(tags, "kubicorn-master")
 	}
 
-	if immutable.KubernetesAPI.Port == "80" {
-		tags = append(tags, "http-server")
+	if r.ServerPool.Type == cluster.ServerPoolTypeNode {
+		tags = append(tags, "kubicorn-node")
 	}
 
 	prefix := "https://www.googleapis.com/compute/v1/projects/" + immutable.CloudId

--- a/docs/_documentation/google-walkthrough.md
+++ b/docs/_documentation/google-walkthrough.md
@@ -60,6 +60,11 @@ $ ls -al ~/.ssh/id_rsa.pub
 -rw-------@ 1 mhausenblas  staff   754B 20 Mar 04:03 /Users/mhausenblas/.ssh/id_rsa.pub
 ```
 
+Finally, it is necessary to create a firewall rule for allowing ingress traffic to the API server, that is esposed by default on tcp:443 in above profile.
+You can use [this guide to create firewall rules](https://cloud.google.com/compute/docs/vpc/using-firewalls); in production systems,
+it is reccomanded to restrict such firewall rule, limiting the target systems e.g. using network tags, and limiting as well
+the range of allowed source systems.
+
 #### Applying
 
 With the access set up, we can now apply the resources we defined in the first step. 


### PR DESCRIPTION
**Why we need this PR**
Currently, when creating an instance group/instance template on GCP, kubicorn applies the same network tags both to master and node groups, and this doesn't help if you plan to use network tags for defining firewall rules as much restrictive as possible. 

With this PR it will be possible e.g. to restrict the ingress traffic only to master nodes by defining a rule that applies only to the VMs with network tag "kubicorn-master"

**Notes for the reviewer** 
- While making the change, I restricted the existing label "http-servers" and "http-server" only to the master server group; however, I'm not sure if the "http-server" label makes sense because kubeadm init always use TLS...
- Ideally other labels could be useful, like e.g. the name of the cluster... if you are aware of some use case for this as well, let me know.
- the PR includes also a small improvement to the google walkthrough, informing users that it is necessary to create a firewall rule to get the things going. 




