### PR TITLE
cmd: implement set flag for apply

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kris-nova/kubicorn/state"
 	"github.com/kris-nova/kubicorn/state/fs"
 	"github.com/spf13/cobra"
+	"github.com/yuroyoro/swalker"
 )
 
 type ApplyOptions struct {
@@ -96,6 +97,17 @@ func RunApply(options *ApplyOptions) error {
 		return fmt.Errorf("Unable to get cluster [%s]: %v", name, err)
 	}
 	logger.Info("Loaded cluster: %s", cluster.Name)
+
+	if options.Set != "" {
+		sets := strings.Split(options.Set, ",")
+		for _, set := range sets {
+			parts := strings.SplitN(set, "=", 2)
+			err := swalker.Write(strings.Title(parts[0]), cluster, parts[1])
+			if err != nil {
+				println(err)
+			}
+		}
+	}
 
 	cluster, err = initapi.InitCluster(cluster)
 	if err != nil {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -102,9 +102,12 @@ func RunApply(options *ApplyOptions) error {
 		sets := strings.Split(options.Set, ",")
 		for _, set := range sets {
 			parts := strings.SplitN(set, "=", 2)
+			if len(parts) == 1 {
+				continue
+			}
 			err := swalker.Write(strings.Title(parts[0]), cluster, parts[1])
 			if err != nil {
-				println(err)
+				logger.Critical("Error expanding set flag: %#v", err)
 			}
 		}
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -150,6 +150,9 @@ func RunCreate(options *CreateOptions) error {
 		sets := strings.Split(options.Set, ",")
 		for _, set := range sets {
 			parts := strings.SplitN(set, "=", 2)
+			if len(parts) == 1 {
+				continue
+			}
 			err := swalker.Write(strings.Title(parts[0]), newCluster, parts[1])
 			if err != nil {
 				println(err)

--- a/cutil/kubeadm/token.go
+++ b/cutil/kubeadm/token.go
@@ -16,6 +16,7 @@ package kubeadm
 
 import (
 	"fmt"
+
 	"github.com/kris-nova/kubicorn/cutil/rand"
 )
 

--- a/cutil/namer/random.go
+++ b/cutil/namer/random.go
@@ -16,6 +16,7 @@ package namer
 
 import (
 	"fmt"
+
 	"github.com/kris-nova/kubicorn/cutil/rand"
 )
 

--- a/cutil/parser/fileresource.go
+++ b/cutil/parser/fileresource.go
@@ -15,9 +15,10 @@
 package fileresource
 
 import (
-	"github.com/kris-nova/kubicorn/bootstrap"
 	"net/url"
 	"strings"
+
+	"github.com/kris-nova/kubicorn/bootstrap"
 )
 
 // ReadFromResource reads a file from different sources

--- a/cutil/uuid/uuid.go
+++ b/cutil/uuid/uuid.go
@@ -16,8 +16,9 @@ package uuid
 
 import (
 	"fmt"
-	"github.com/kris-nova/kubicorn/cutil/rand"
 	"time"
+
+	"github.com/kris-nova/kubicorn/cutil/rand"
 )
 
 // Generates a time ordered UUID. Top 32b are timestamp bottom 96b are random.


### PR DESCRIPTION
Addresses part of the #417 issue.
This PR implements `--set` logic for the `apply` command.