### PR TITLE
Fix for #372 - support full AWS SDK authentication (ENV, ~/.aws/crede…

### DIFF
--- a/cloud/amazon/awsSdkGo/sdk.go
+++ b/cloud/amazon/awsSdkGo/sdk.go
@@ -15,9 +15,6 @@
 package awsSdkGo
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -33,12 +30,6 @@ type Sdk struct {
 }
 
 func NewSdk(region string) (*Sdk, error) {
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		return nil, fmt.Errorf("Empty $AWS_ACCESS_KEY_ID")
-	}
-	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		return nil, fmt.Errorf("Empty $AWS_SECRET_ACCESS_KEY")
-	}
 	sdk := &Sdk{}
 	session, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{Region: aws.String(region)},


### PR DESCRIPTION
…ntials and instance profile roles)

There were 2 or 3 issues/asks recently (latest is #372) to support the full AWS authentication chain. By default AWS SDK support ENV, ~/.aws/credentials and instance profile based authentication (in this order) and does fallback until fails. This PR removes the short-circuit which forces Kubicorn to fail if the environment variables are missing. Also the SDK provides meaningful error messages in case none of the above are present. 