### PR TITLE
Adding the `--aws-profile` command line option to the creational commands.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Eric Hole <eric.hole@gmail.com>
 fabriziopandini <fabrizio.pandini@gmail.com>
 Igor Vuk <parcijala@gmail.com>
 Joe Beda <joe.github@bedafamily.com>
+Jonathan Frederickson <jonathan@terracrypt.net>
 Joshua Carp <jm.carp@gmail.com>
 Kris Nova <kris@nivenly.com>
 Lachlan Evenson <lachlan.evenson@gmail.com>

--- a/cloud/amazon/awsSdkGo/sdk.go
+++ b/cloud/amazon/awsSdkGo/sdk.go
@@ -29,13 +29,14 @@ type Sdk struct {
 	ASG *autoscaling.AutoScaling
 }
 
-func NewSdk(region string) (*Sdk, error) {
+func NewSdk(region string, profile string) (*Sdk, error) {
 	sdk := &Sdk{}
 	session, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{Region: aws.String(region)},
 		// Support MFA when authing using assumed roles.
 		SharedConfigState:       session.SharedConfigEnable,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+		Profile:                 profile,
 	})
 	if err != nil {
 		return nil, err

--- a/cloud/amazon/awsSdkGo/sdk_test.go
+++ b/cloud/amazon/awsSdkGo/sdk_test.go
@@ -15,35 +15,16 @@
 package awsSdkGo
 
 import (
-	"os"
 	"testing"
-)
-
-var (
-	AwsAccessKey       = os.Getenv("AWS_ACCESS_KEY_ID")
-	AwsSecretAccessKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
 )
 
 func TestMain(m *testing.M) {
 	m.Run()
-	os.Setenv("AWS_ACCESS_KEY_ID", AwsAccessKey)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", AwsSecretAccessKey)
 }
 
-func TestSdkHappy(t *testing.T) {
-	os.Setenv("AWS_ACCESS_KEY_ID", "123")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "123")
-	_, err := NewSdk("us-west-2")
+func TestSdk(t *testing.T) {
+	_, err := NewSdk("us-west-2", "default")
 	if err != nil {
 		t.Fatalf("Unable to get Amazon SDK: %v", err)
-	}
-}
-
-func TestSdkSad(t *testing.T) {
-	os.Setenv("AWS_ACCESS_KEY_ID", "")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	_, err := NewSdk("us-west-2")
-	if err == nil {
-		t.Fatalf("Able to get Amazon SDK with empty variables")
 	}
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -66,6 +66,7 @@ func init() {
 	applyCmd.Flags().StringVarP(&ao.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	applyCmd.Flags().StringVarP(&ao.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	applyCmd.Flags().StringVarP(&ao.Set, "set", "e", strEnvDef("KUBICORN_SET", ""), "set cluster setting")
+	applyCmd.Flags().StringVar(&ao.AwsProfile, "aws-profile", strEnvDef("KUBICORN_AWS_PROFILE", ""), "The profile to be used as defined in $HOME/.aws/credentials")
 	RootCmd.AddCommand(applyCmd)
 }
 
@@ -102,7 +103,13 @@ func RunApply(options *ApplyOptions) error {
 		return err
 	}
 
-	reconciler, err := cutil.GetReconciler(cluster)
+	runtimeParams := &cutil.RuntimeParameters{}
+
+	if len(ao.AwsProfile) > 0 {
+		runtimeParams.AwsProfile = ao.AwsProfile
+	}
+
+	reconciler, err := cutil.GetReconciler(cluster, runtimeParams)
 	if err != nil {
 		return fmt.Errorf("Unable to get reconciler: %v", err)
 	}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -69,6 +69,7 @@ func init() {
 	deleteCmd.Flags().StringVarP(&do.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
 	deleteCmd.Flags().StringVarP(&do.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
 	deleteCmd.Flags().BoolVarP(&do.Purge, "purge", "p", false, "Remove the API model from the state store after the resources are deleted.")
+	deleteCmd.Flags().StringVar(&ao.AwsProfile, "aws-profile", strEnvDef("KUBICORN_AWS_PROFILE", ""), "The profile to be used as defined in $HOME/.aws/credentials")
 
 	RootCmd.AddCommand(deleteCmd)
 }
@@ -104,7 +105,13 @@ func RunDelete(options *DeleteOptions) error {
 		return fmt.Errorf("Unable to get cluster [%s]: %v", name, err)
 	}
 
-	reconciler, err := cutil.GetReconciler(expectedCluster)
+	runtimeParams := &cutil.RuntimeParameters{}
+
+	if len(ao.AwsProfile) > 0 {
+		runtimeParams.AwsProfile = ao.AwsProfile
+	}
+
+	reconciler, err := cutil.GetReconciler(expectedCluster, runtimeParams)
 	if err != nil {
 		return fmt.Errorf("Unable to get cluster reconciler: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ type Options struct {
 	Name           string
 	CloudId        string
 	Set            string
+	AwsProfile     string
 }
 
 func Execute() {

--- a/cutil/reconciler.go
+++ b/cutil/reconciler.go
@@ -33,8 +33,15 @@ import (
 	"github.com/kris-nova/kubicorn/cloud/google/googleSDK"
 )
 
+// RuntimeParameters contains specific parameters that needs to be passed to each
+// cloud provider to satisfy their specific configurations needs at runtime while
+// using the Reconciler
+type RuntimeParameters struct {
+	AwsProfile string
+}
+
 // GetReconciler gets the correct Reconciler for the cloud provider currenty used.
-func GetReconciler(known *cluster.Cluster) (reconciler cloud.Reconciler, err error) {
+func GetReconciler(known *cluster.Cluster, runtimeParameters *RuntimeParameters) (reconciler cloud.Reconciler, err error) {
 
 	switch known.Cloud {
 	case cluster.CloudGoogle:
@@ -52,7 +59,7 @@ func GetReconciler(known *cluster.Cluster) (reconciler cloud.Reconciler, err err
 		dr.Sdk = sdk
 		return cloud.NewAtomicReconciler(known, droplet.NewDigitalOceanDropletModel(known)), nil
 	case cluster.CloudAmazon:
-		sdk, err := awsSdkGo.NewSdk(known.Location)
+		sdk, err := awsSdkGo.NewSdk(known.Location, runtimeParameters.AwsProfile)
 		if err != nil {
 			return nil, err
 		}

--- a/examples/amazon/basiccluster.go
+++ b/examples/amazon/basiccluster.go
@@ -28,7 +28,8 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	reconciler, err := cutil.GetReconciler(cluster)
+
+	reconciler, err := cutil.GetReconciler(cluster, &cutil.RuntimeParameters{AwsProfile: "default"})
 	if err != nil {
 		panic(err.Error())
 	}

--- a/examples/digitalocean/basiccluster.go
+++ b/examples/digitalocean/basiccluster.go
@@ -28,7 +28,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	reconciler, err := cutil.GetReconciler(cluster)
+	reconciler, err := cutil.GetReconciler(cluster, nil)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/examples/google/compute/basiccluster.go
+++ b/examples/google/compute/basiccluster.go
@@ -28,7 +28,7 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-	reconciler, err := cutil.GetReconciler(cluster)
+	reconciler, err := cutil.GetReconciler(cluster, nil)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -26,7 +26,7 @@ func Create(testCluster *cluster.Cluster) (*cluster.Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	reconciler, err := cutil.GetReconciler(testCluster)
+	reconciler, err := cutil.GetReconciler(testCluster, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func Create(testCluster *cluster.Cluster) (*cluster.Cluster, error) {
 
 // Read will read a test cluster
 func Read(testCluster *cluster.Cluster) (*cluster.Cluster, error) {
-	reconciler, err := cutil.GetReconciler(testCluster)
+	reconciler, err := cutil.GetReconciler(testCluster, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func Update(testCluster *cluster.Cluster) (*cluster.Cluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	reconciler, err := cutil.GetReconciler(testCluster)
+	reconciler, err := cutil.GetReconciler(testCluster, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func Update(testCluster *cluster.Cluster) (*cluster.Cluster, error) {
 
 // Delete will delete a test cluster
 func Delete(testCluster *cluster.Cluster) (*cluster.Cluster, error) {
-	reconciler, err := cutil.GetReconciler(testCluster)
+	reconciler, err := cutil.GetReconciler(testCluster, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Referring to #440 
I preferred to use a different approach than setting the environment variable as proposed in the issue since the `Profile` option was already there in the Sdk.

I felt free to add a new parameter  to `cutil.GetReconciler` so that each adapter
can pass its own specific parameters needed at *runtime*.

In my opinion this is ideal since there's a whole kind of parameters that does not necessarily fits into the state, like in this case with the need to actually choose a profile from the `~/.aws/credentials` which is not related to the actual state but to the way the user want to run the whole thing at a specific moment.

Closes #440

Example:
```
  kubicorn apply --aws-profile default mycluster
```

Signed-off-by: Lorenzo Fontana <lo@linux.com>