### PR TITLE
Documentation around GCP and cloud ID arg

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -158,7 +158,7 @@ func RunCreate(options *CreateOptions) error {
 	}
 
 	if newCluster.Cloud == cluster.CloudGoogle && options.CloudId == "" {
-		return fmt.Errorf("CloudID is required for google cloud.")
+		return fmt.Errorf("CloudID is required for google cloud. Please set it to your project ID")
 	}
 	newCluster.CloudId = options.CloudId
 

--- a/docs/_documentation/google-walkthrough.md
+++ b/docs/_documentation/google-walkthrough.md
@@ -24,11 +24,11 @@ In the following we'll be using an existing profile called `do`, which is a prof
 
 You will need to create a project in you google cloud account.
 This project will get a projectid, something like `kubicorn-132742`.
-When using Google Cloud Compute Egnine the `kubicorn` name and the project ID need to be the same value.
+When using Google Cloud Compute Engine the `kubicorn` name, the `cloudid` argument, and the project ID need to be the same value.
 Now execute the following command:
 
 ```
-$ kubicorn create --name kubicorn-132742 --profile google
+$ kubicorn create --name kubicorn-132742 --profile google --cloudid kubicorn-132742
 ```
 
 Verify that `kubicorn create` did a good job by executing:

--- a/docs/docs_old/google/walkthrough.md
+++ b/docs/docs_old/google/walkthrough.md
@@ -19,11 +19,11 @@ In the following we'll be using an existing profile called `do`, which is a prof
 
 You will need to create a project in you google cloud account.
 This project will get a projectid, something like kubicorn-132742.
-When using Google Cloud Compute Egnine the Kubicorn name and the project ID need to be the same value.
+When using Google Cloud Compute Engine the `kubicorn` name, the `cloudid` argument, and the project ID need to be the same value.
 Now execute the following command:
 
 ```
-$ kubicorn create --name kubicorn-132742 --profile google
+$ kubicorn create --name kubicorn-132742 --profile google --cloudid kubicorn-132742
 ```
 
 Verify that `kubicorn create` did a good job by executing:


### PR DESCRIPTION
Added cloud ID arg to example commands for creating a cluster with GCP as well as a suggestion on what it needs to be when the arg is unset 