### PR TITLE
Reorganise profiles into dirs for each provider

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -24,7 +24,10 @@ import (
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/logger"
 	"github.com/kris-nova/kubicorn/cutil/namer"
-	"github.com/kris-nova/kubicorn/profiles"
+	"github.com/kris-nova/kubicorn/profiles/amazon"
+	"github.com/kris-nova/kubicorn/profiles/azure"
+	"github.com/kris-nova/kubicorn/profiles/digitalocean"
+	"github.com/kris-nova/kubicorn/profiles/googlecompute"
 	"github.com/kris-nova/kubicorn/state"
 	"github.com/kris-nova/kubicorn/state/fs"
 	"github.com/kris-nova/kubicorn/state/jsonfs"
@@ -95,47 +98,47 @@ type profileMap struct {
 
 var profileMapIndexed = map[string]profileMap{
 	"azure": {
-		profileFunc: profiles.NewUbuntuAzureCluster,
+		profileFunc: azure.NewUbuntuCluster,
 		description: "Ubuntu on Azure",
 	},
 	"azure-ubuntu": {
-		profileFunc: profiles.NewUbuntuAzureCluster,
+		profileFunc: azure.NewUbuntuCluster,
 		description: "Ubuntu on Azure",
 	},
 	"amazon": {
-		profileFunc: profiles.NewUbuntuAmazonCluster,
+		profileFunc: amazon.NewUbuntuCluster,
 		description: "Ubuntu on Amazon",
 	},
 	"aws": {
-		profileFunc: profiles.NewUbuntuAmazonCluster,
+		profileFunc: amazon.NewUbuntuCluster,
 		description: "Ubuntu on Amazon",
 	},
 	"do": {
-		profileFunc: profiles.NewUbuntuDigitalOceanCluster,
+		profileFunc: digitalocean.NewUbuntuCluster,
 		description: "Ubuntu on DigitalOcean",
 	},
 	"google": {
-		profileFunc: profiles.NewUbuntuGoogleComputeCluster,
+		profileFunc: googlecompute.NewUbuntuCluster,
 		description: "Ubuntu on Google Compute",
 	},
 	"digitalocean": {
-		profileFunc: profiles.NewUbuntuDigitalOceanCluster,
+		profileFunc: digitalocean.NewUbuntuCluster,
 		description: "Ubuntu on DigitalOcean",
 	},
 	"do-ubuntu": {
-		profileFunc: profiles.NewUbuntuDigitalOceanCluster,
+		profileFunc: digitalocean.NewUbuntuCluster,
 		description: "Ubuntu on DigitalOcean",
 	},
 	"aws-ubuntu": {
-		profileFunc: profiles.NewUbuntuAmazonCluster,
+		profileFunc: amazon.NewUbuntuCluster,
 		description: "Ubuntu on Amazon",
 	},
 	"do-centos": {
-		profileFunc: profiles.NewCentosDigitalOceanCluster,
+		profileFunc: digitalocean.NewCentosCluster,
 		description: "CentOS on DigitalOcean",
 	},
 	"aws-centos": {
-		profileFunc: profiles.NewCentosAmazonCluster,
+		profileFunc: amazon.NewCentosCluster,
 		description: "CentOS on Amazon",
 	},
 }

--- a/cutil/script/script_test.go
+++ b/cutil/script/script_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/kris-nova/kubicorn/apis/cluster"
-	"github.com/kris-nova/kubicorn/profiles"
+	"github.com/kris-nova/kubicorn/profiles/amazon"
 )
 
 func TestBuildBootstrapScriptHappy(t *testing.T) {
@@ -53,7 +53,7 @@ func TestBuildBootstrapSetupScript(t *testing.T) {
 cat <<"EOF" > ./test.json`
 	expectedEnd := "\nEOF\n"
 
-	c := profiles.NewCentosAmazonCluster("bootstrap-setup-script-test")
+	c := amazon.NewCentosCluster("bootstrap-setup-script-test")
 	os.Remove(dir + "/" + fileName)
 	os.Remove("test.sh")
 	script, err := buildBootstrapSetupScript(c, dir, fileName)

--- a/examples/amazon/basiccluster.go
+++ b/examples/amazon/basiccluster.go
@@ -18,12 +18,12 @@ import (
 	"github.com/kris-nova/kubicorn/cutil"
 	"github.com/kris-nova/kubicorn/cutil/initapi"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"github.com/kris-nova/kubicorn/profiles"
+	"github.com/kris-nova/kubicorn/profiles/amazon"
 )
 
 func main() {
 	logger.Level = 4
-	cluster := profiles.NewUbuntuAmazonCluster("myCluster")
+	cluster := amazon.NewUbuntuCluster("myCluster")
 	cluster, err := initapi.InitCluster(cluster)
 	if err != nil {
 		panic(err.Error())

--- a/examples/digitalocean/basiccluster.go
+++ b/examples/digitalocean/basiccluster.go
@@ -18,12 +18,12 @@ import (
 	"github.com/kris-nova/kubicorn/cutil"
 	"github.com/kris-nova/kubicorn/cutil/initapi"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"github.com/kris-nova/kubicorn/profiles"
+	"github.com/kris-nova/kubicorn/profiles/digitalocean"
 )
 
 func main() {
 	logger.Level = 4
-	cluster := profiles.NewUbuntuDigitalOceanCluster("myCluster")
+	cluster := digitalocean.NewUbuntuCluster("myCluster")
 	cluster, err := initapi.InitCluster(cluster)
 	if err != nil {
 		panic(err.Error())

--- a/examples/google/compute/basiccluster.go
+++ b/examples/google/compute/basiccluster.go
@@ -18,12 +18,12 @@ import (
 	"github.com/kris-nova/kubicorn/cutil"
 	"github.com/kris-nova/kubicorn/cutil/initapi"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"github.com/kris-nova/kubicorn/profiles"
+	"github.com/kris-nova/kubicorn/profiles/googlecompute"
 )
 
 func main() {
 	logger.Level = 4
-	cluster := profiles.NewUbuntuGoogleComputeCluster("myCluster")
+	cluster := googlecompute.NewUbuntuCluster("myCluster")
 	cluster, err := initapi.InitCluster(cluster)
 	if err != nil {
 		panic(err.Error())

--- a/profiles/amazon/centos_7.go
+++ b/profiles/amazon/centos_7.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package profiles
+package amazon
 
 import (
 	"fmt"
@@ -22,7 +22,8 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/uuid"
 )
 
-func NewCentosAmazonCluster(name string) *cluster.Cluster {
+// NewCentosCluster creates a simple CentOS Amazon cluster
+func NewCentosCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
 		Cloud:    cluster.CloudAmazon,

--- a/profiles/amazon/ubuntu_16_04.go
+++ b/profiles/amazon/ubuntu_16_04.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package profiles
+package amazon
 
 import (
 	"fmt"
@@ -22,8 +22,8 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/uuid"
 )
 
-// NewUbuntuAmazonCluster creates a simple Ubuntu Amazon cluster
-func NewUbuntuAmazonCluster(name string) *cluster.Cluster {
+// NewUbuntuCluster creates a simple Ubuntu Amazon cluster
+func NewUbuntuCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
 		Cloud:    cluster.CloudAmazon,

--- a/profiles/azure/ubuntu.go
+++ b/profiles/azure/ubuntu.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package profiles
+package azure
 
 import (
 	"fmt"
@@ -21,8 +21,8 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/kubeadm"
 )
 
-// NewUbuntuAzureCluster creates a basic Digitalocean cluster profile, to bootstrap Kubernetes.
-func NewUbuntuAzureCluster(name string) *cluster.Cluster {
+// NewUbuntuCluster creates a basic Azure cluster profile, to bootstrap Kubernetes.
+func NewUbuntuCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
 		Cloud:    cluster.CloudAzure,

--- a/profiles/digitalocean/centos_7.go
+++ b/profiles/digitalocean/centos_7.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package profiles
+package digitalocean
 
 import (
 	"fmt"
@@ -21,8 +21,8 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/kubeadm"
 )
 
-// NewCentosDigitalOceanCluster creates a basic CentOS DigitalOcean cluster.
-func NewCentosDigitalOceanCluster(name string) *cluster.Cluster {
+// NewCentosCluster creates a basic CentOS DigitalOcean cluster.
+func NewCentosCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
 		Cloud:    cluster.CloudDigitalOcean,

--- a/profiles/digitalocean/ubuntu_16_04.go
+++ b/profiles/digitalocean/ubuntu_16_04.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package profiles
+package digitalocean
 
 import (
 	"fmt"
@@ -21,8 +21,8 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/kubeadm"
 )
 
-// NewUbuntuDigitalOceanCluster creates a basic Digitalocean cluster profile, to bootstrap Kubernetes.
-func NewUbuntuDigitalOceanCluster(name string) *cluster.Cluster {
+// NewUbuntuCluster creates a basic Digitalocean cluster profile, to bootstrap Kubernetes.
+func NewUbuntuCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
 		Cloud:    cluster.CloudDigitalOcean,

--- a/profiles/googlecompute/ubuntu_16_04.go
+++ b/profiles/googlecompute/ubuntu_16_04.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package profiles
+package googlecompute
 
 import (
 	"fmt"
@@ -21,8 +21,8 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/kubeadm"
 )
 
-// NewUbuntuGoogleComputeCluster creates a basic Ubuntu Google Compute cluster.
-func NewUbuntuGoogleComputeCluster(name string) *cluster.Cluster {
+// NewUbuntuCluster creates a basic Ubuntu Google Compute cluster.
+func NewUbuntuCluster(name string) *cluster.Cluster {
 	return &cluster.Cluster{
 		Name:     name,
 		CloudId:  "example-id",

--- a/state/fs/impl_test.go
+++ b/state/fs/impl_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/kris-nova/kubicorn/apis/cluster"
-	"github.com/kris-nova/kubicorn/profiles"
+	"github.com/kris-nova/kubicorn/profiles/amazon"
 	"github.com/kris-nova/kubicorn/state"
 )
 
@@ -30,7 +30,7 @@ func TestStateFileSystem(t *testing.T) {
 	testFilePath := ".test"
 	clusterName := "fstest"
 
-	c := profiles.NewUbuntuAmazonCluster(clusterName)
+	c := amazon.NewUbuntuCluster(clusterName)
 	o := &FileSystemStoreOptions{
 		BasePath:    testFilePath,
 		ClusterName: c.Name,

--- a/state/jsonfs/impl_test.go
+++ b/state/jsonfs/impl_test.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 
 	"github.com/kris-nova/kubicorn/apis/cluster"
-	"github.com/kris-nova/kubicorn/profiles"
+	"github.com/kris-nova/kubicorn/profiles/amazon"
 	"github.com/kris-nova/kubicorn/state"
 )
 
 func TestJsonFileSystem(t *testing.T) {
 	testFilePath := ".test/"
 	clusterName := "jsonfs-test"
-	c := profiles.NewUbuntuAmazonCluster(clusterName)
+	c := amazon.NewUbuntuCluster(clusterName)
 	o := &JSONFileSystemStoreOptions{
 		BasePath:    testFilePath,
 		ClusterName: c.Name,

--- a/test/amazon/centos_cluster_test.go
+++ b/test/amazon/centos_cluster_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kris-nova/charlie/network"
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"github.com/kris-nova/kubicorn/profiles"
+	profile "github.com/kris-nova/kubicorn/profiles/amazon"
 	"github.com/kris-nova/kubicorn/test"
 	"os"
 	"testing"
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 	//	}
 	//}()
 	test.InitRsaTravis()
-	testCluster = profiles.NewCentosAmazonCluster("centos-test")
+	testCluster = profile.NewCentosCluster("centos-test")
 	testCluster, err = test.Create(testCluster)
 	if err != nil {
 		fmt.Printf("Unable to create Amazon test cluster: %v\n", err)

--- a/test/amazon/ubuntu_cluster_test.go
+++ b/test/amazon/ubuntu_cluster_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kris-nova/charlie/network"
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"github.com/kris-nova/kubicorn/profiles"
+	profile "github.com/kris-nova/kubicorn/profiles/amazon"
 	"github.com/kris-nova/kubicorn/test"
 	"os"
 	"testing"
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 	//	}
 	//}()
 	test.InitRsaTravis()
-	testCluster = profiles.NewUbuntuAmazonCluster("ubuntu-test")
+	testCluster = profile.NewUbuntuCluster("ubuntu-test")
 	testCluster, err = test.Create(testCluster)
 	if err != nil {
 		fmt.Printf("Unable to create Amazon test cluster: %v\n", err)

--- a/test/digitalocean/centos_cluster_test.go
+++ b/test/digitalocean/centos_cluster_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kris-nova/charlie/network"
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"github.com/kris-nova/kubicorn/profiles"
+	profile "github.com/kris-nova/kubicorn/profiles/digitalocean"
 	"github.com/kris-nova/kubicorn/test"
 	"os"
 	"testing"
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 	//	}
 	//}()
 	test.InitRsaTravis()
-	testCluster = profiles.NewCentosDigitalOceanCluster("centos-test")
+	testCluster = profile.NewCentosCluster("centos-test")
 	testCluster, err = test.Create(testCluster)
 	if err != nil {
 		fmt.Printf("Unable to create DigitalOcean test cluster: %v\n", err)

--- a/test/digitalocean/ubuntu_cluster_test.go
+++ b/test/digitalocean/ubuntu_cluster_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kris-nova/charlie/network"
 	"github.com/kris-nova/kubicorn/apis/cluster"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"github.com/kris-nova/kubicorn/profiles"
+	profile "github.com/kris-nova/kubicorn/profiles/digitalocean"
 	"github.com/kris-nova/kubicorn/test"
 	"os"
 	"testing"
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 	//	}
 	//}()
 	test.InitRsaTravis()
-	testCluster = profiles.NewUbuntuDigitalOceanCluster("ubuntu-test")
+	testCluster = profile.NewUbuntuCluster("ubuntu-test")
 	testCluster, err = test.Create(testCluster)
 	if err != nil {
 		fmt.Printf("Unable to create DigitalOcean test cluster: %v\n", err)


### PR DESCRIPTION
This PR is related to #453. It was actually a straightforward renaming and moving of files. Because all the functions in the profiles exist in the `profiles` package (both before and after the refactor), there were no code changes needed as far as I could see.

I tested this by building a local binary of `kubicorn` with the new profile layout and successfully created an Ubuntu cluster on AWS.

Unfortunately I wasn't able to get `make test` running successfully (even before making any code changes) so I wasn't able to verify that the tests also didn't need any code changes, but from reading the code this seems to be okay also.