### PR TITLE
Now AZs for both master/nodes subnets will be correctly set on cluster creation

### DIFF
--- a/cloud/amazon/public/resources/subnet.go
+++ b/cloud/amazon/public/resources/subnet.go
@@ -73,6 +73,7 @@ func (r *Subnet) Actual(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Res
 		}
 	} else {
 		newResource.CIDR = r.ClusterSubnet.CIDR
+		newResource.Zone = r.ClusterSubnet.Zone
 	}
 
 	newCluster := r.immutableRender(newResource, immutable)
@@ -94,6 +95,7 @@ func (r *Subnet) Expected(immutable *cluster.Cluster) (*cluster.Cluster, cloud.R
 		VpcID: immutable.Network.Identifier,
 		Zone:  r.ClusterSubnet.Zone,
 	}
+
 	newCluster := r.immutableRender(newResource, immutable)
 	return newCluster, newResource, nil
 }
@@ -107,6 +109,7 @@ func (r *Subnet) Apply(actual, expected cloud.Resource, immutable *cluster.Clust
 	if isEqual {
 		return immutable, applyResource, nil
 	}
+
 	input := &ec2.CreateSubnetInput{
 		CidrBlock:        &expected.(*Subnet).CIDR,
 		VpcId:            &immutable.Network.Identifier,

--- a/profiles/amazon/centos_7.go
+++ b/profiles/amazon/centos_7.go
@@ -58,9 +58,9 @@ func NewCentosCluster(name string) *cluster.Cluster {
 				},
 				Subnets: []*cluster.Subnet{
 					{
-						Name:     fmt.Sprintf("%s.master", name),
-						CIDR:     "10.0.0.0/24",
-						Location: "us-west-2a",
+						Name: fmt.Sprintf("%s.master", name),
+						CIDR: "10.0.0.0/24",
+						Zone: "us-west-2a",
 					},
 				},
 
@@ -102,9 +102,9 @@ func NewCentosCluster(name string) *cluster.Cluster {
 				},
 				Subnets: []*cluster.Subnet{
 					{
-						Name:     fmt.Sprintf("%s.node", name),
-						CIDR:     "10.0.100.0/24",
-						Location: "us-west-2b",
+						Name: fmt.Sprintf("%s.node", name),
+						CIDR: "10.0.100.0/24",
+						Zone: "us-west-2b",
 					},
 				},
 				Firewalls: []*cluster.Firewall{

--- a/profiles/amazon/ubuntu_16_04.go
+++ b/profiles/amazon/ubuntu_16_04.go
@@ -58,9 +58,9 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 				},
 				Subnets: []*cluster.Subnet{
 					{
-						Name:     fmt.Sprintf("%s.master", name),
-						CIDR:     "10.0.0.0/24",
-						Location: "us-west-2a",
+						Name: fmt.Sprintf("%s.master", name),
+						CIDR: "10.0.0.0/24",
+						Zone: "us-west-2a",
 					},
 				},
 				AwsConfiguration: &cluster.AwsConfiguration{},
@@ -102,9 +102,9 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 				},
 				Subnets: []*cluster.Subnet{
 					{
-						Name:     fmt.Sprintf("%s.node", name),
-						CIDR:     "10.0.100.0/24",
-						Location: "us-west-2b",
+						Name: fmt.Sprintf("%s.node", name),
+						CIDR: "10.0.100.0/24",
+						Zone: "us-west-2b",
 					},
 				},
 				AwsConfiguration: &cluster.AwsConfiguration{},


### PR DESCRIPTION
The current AWS implementation is broken when it comes to correctly define subnets in the configured AZs. By default the `create` command from the model defines `Location` in the subnets definitions but in `cloud/amazon/public/resources/subnet.go:96` we are setting `Zone:  r.ClusterSubnet.Zone`. 
`r.ClusterSubnet.Zone` is not defined which causes subnets to default to a random AZ.

One would think that the quick win is to simply change the model to set the `Zone` field instead of `Location`, unfortunately this isn't working as expected due to a race condition and shared structures state in `cloud/amazon/public/resources/subnet.go`. What happens here, starting at line `:48`, is that because `r.ClusterSubnet.Identifier` is empty on cluster creation, only the `else` condition is evaluated and `Zone` is left empty.

This 1 line change is the result of some serious debugging by me, [Gabriele](https://github.com/gabrielelana) and [Simone](https://github.com/siscia).

One important change introduced by this PR consists in breaking changes in the `yaml` definition where `ServerPools` will drop the field `Location` and have instead a `Zone` field. Still, we feel this was the intended original implementation.