### PR TITLE
Fix 404 footer width by dropping overridden container

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="row text-center">
   <div class="col-12">
-    <p><h1>404</h1></p>
+    <p><h1 class="display-1">404</h1></p>
     <p><strong>Page not found :(</strong></p>
     <p>The requested page could not be found.</p>
   </div>

--- a/docs/404.html
+++ b/docs/404.html
@@ -2,23 +2,10 @@
 layout: default
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
-  <h1>404</h1>
-
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
+<div class="row text-center">
+  <div class="col-12">
+    <p><h1>404</h1></p>
+    <p><strong>Page not found :(</strong></p>
+    <p>The requested page could not be found.</p>
+  </div>
 </div>

--- a/docs/_site/404.html
+++ b/docs/_site/404.html
@@ -143,7 +143,7 @@
       <div class="wrapper">
         <div class="row text-center">
   <div class="col-12">
-    <p><h1>404</h1></p>
+    <p><h1 class="display-1">404</h1></p>
     <p><strong>Page not found :(</strong></p>
     <p>The requested page could not be found.</p>
   </div>

--- a/docs/_site/404.html
+++ b/docs/_site/404.html
@@ -141,25 +141,12 @@
 
     <main class="page-content" aria-label="Content">
       <div class="wrapper">
-        <style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
-  <h1>404</h1>
-
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
+        <div class="row text-center">
+  <div class="col-12">
+    <p><h1>404</h1></p>
+    <p><strong>Page not found :(</strong></p>
+    <p>The requested page could not be found.</p>
+  </div>
 </div>
 
       </div>


### PR DESCRIPTION
Not sure why it was needed just for 404s?

Fixes #378

![image](https://user-images.githubusercontent.com/2572493/31956296-440a485e-b8eb-11e7-80ff-94e44307b426.png)
