### PR TITLE
Add AWS instance profile support

### DIFF
--- a/apis/cluster/instanceprofile.go
+++ b/apis/cluster/instanceprofile.go
@@ -1,0 +1,41 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type IAMInstanceProfile struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Name              string   `json:"name,omitempty"`
+	Identifier        string   `json:"identifier,omitempty"`
+	Role              *IAMRole `json:"role,omitempty"`
+}
+
+type IAMRole struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Name              string       `json:"name,omitempty"`
+	Identifier        string       `json:"identifier,omitempty"`
+	Policies          []*IAMPolicy `json:"policies,omitempty"`
+}
+
+type IAMPolicy struct {
+	Name       string `json:"name,omitempty"`
+	Document   string `json:"document,omitempty"`
+	Identifier string `json:"identifier,omitempty"`
+}

--- a/apis/cluster/serverpool.go
+++ b/apis/cluster/serverpool.go
@@ -27,17 +27,18 @@ const (
 type ServerPool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Identifier        string            `json:"identifier,omitempty"`
-	MinCount          int               `json:"minCount,omitempty"`
-	MaxCount          int               `json:"maxCount,omitempty"`
-	Type              string            `json:"type,omitempty"`
-	Name              string            `json:"name,omitempty"`
-	Image             string            `json:"image,omitempty"`
-	Size              string            `json:"size,omitempty"`
-	BootstrapScripts  []string          `json:"bootstrapScripts,omitempty"`
-	Subnets           []*Subnet         `json:"subnets,omitempty"`
-	Firewalls         []*Firewall       `json:"firewalls,omitempty"`
-	AwsConfiguration  *AwsConfiguration `json:"awsconfiguration,omitempty"`
+	Identifier        string              `json:"identifier,omitempty"`
+	MinCount          int                 `json:"minCount,omitempty"`
+	MaxCount          int                 `json:"maxCount,omitempty"`
+	Type              string              `json:"type,omitempty"`
+	Name              string              `json:"name,omitempty"`
+	Image             string              `json:"image,omitempty"`
+	Size              string              `json:"size,omitempty"`
+	InstanceProfile   *IAMInstanceProfile `json:"instanceProfile,omitempty"`
+	BootstrapScripts  []string            `json:"bootstrapScripts,omitempty"`
+	Subnets           []*Subnet           `json:"subnets,omitempty"`
+	Firewalls         []*Firewall         `json:"firewalls,omitempty"`
+	AwsConfiguration  *AwsConfiguration   `json:"awsconfiguration,omitempty"`
 }
 
 type AwsConfiguration struct {

--- a/cloud/amazon/awsSdkGo/sdk.go
+++ b/cloud/amazon/awsSdkGo/sdk.go
@@ -21,22 +21,23 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/iam"
 )
 
 type Sdk struct {
 	Ec2 *ec2.EC2
 	S3  *s3.S3
 	ASG *autoscaling.AutoScaling
+	IAM *iam.IAM
 }
 
-func NewSdk(region string, profile string) (*Sdk, error) {
+func NewSdk(region string) (*Sdk, error) {
 	sdk := &Sdk{}
 	session, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{Region: aws.String(region)},
 		// Support MFA when authing using assumed roles.
 		SharedConfigState:       session.SharedConfigEnable,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
-		Profile:                 profile,
 	})
 	if err != nil {
 		return nil, err
@@ -44,5 +45,6 @@ func NewSdk(region string, profile string) (*Sdk, error) {
 	sdk.Ec2 = ec2.New(session)
 	sdk.ASG = autoscaling.New(session)
 	sdk.S3 = s3.New(session)
+	sdk.IAM = iam.New(session)
 	return sdk, nil
 }

--- a/cloud/amazon/awsSdkGo/sdk.go
+++ b/cloud/amazon/awsSdkGo/sdk.go
@@ -20,8 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 type Sdk struct {

--- a/cloud/amazon/awsSdkGo/sdk.go
+++ b/cloud/amazon/awsSdkGo/sdk.go
@@ -20,8 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/iam"
 )
 
 type Sdk struct {
@@ -31,13 +31,14 @@ type Sdk struct {
 	IAM *iam.IAM
 }
 
-func NewSdk(region string) (*Sdk, error) {
+func NewSdk(region string, profile string) (*Sdk, error) {
 	sdk := &Sdk{}
 	session, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{Region: aws.String(region)},
 		// Support MFA when authing using assumed roles.
 		SharedConfigState:       session.SharedConfigEnable,
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+		Profile:                 profile,
 	})
 	if err != nil {
 		return nil, err

--- a/cloud/amazon/public/resources/instanceprofile.go
+++ b/cloud/amazon/public/resources/instanceprofile.go
@@ -1,0 +1,339 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/kris-nova/kubicorn/apis/cluster"
+	"github.com/kris-nova/kubicorn/cloud"
+	"github.com/kris-nova/kubicorn/cutil/compare"
+	"github.com/kris-nova/kubicorn/cutil/defaults"
+	"github.com/kris-nova/kubicorn/cutil/logger"
+	"net/url"
+)
+
+var _ cloud.Resource = &InstanceProfile{}
+
+type InstanceProfile struct {
+	Shared
+	Role       *IAMRole
+	ServerPool *cluster.ServerPool
+}
+
+type IAMRole struct {
+	Shared
+	Policies []*IAMPolicy
+}
+
+type IAMPolicy struct {
+	Shared
+	Document string
+}
+
+func (r *InstanceProfile) Actual(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resource, error) {
+	logger.Debug("instanceprofile.Actual")
+	newResource := &InstanceProfile{
+		Shared: Shared{
+			Name: r.Name,
+			Tags: map[string]string{
+				"Name":              r.Name,
+				"KubernetesCluster": immutable.Name,
+			},
+		},
+		ServerPool: r.ServerPool,
+	}
+	// Get InstanceProfile
+	if r.Identifier != "" {
+		logger.Debug("Query InstanceProfile: %v", newResource.Name)
+		respInstanceProfile, err := Sdk.IAM.GetInstanceProfile(&iam.GetInstanceProfileInput{
+			InstanceProfileName: &newResource.Name,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		newResource.Identifier = *respInstanceProfile.InstanceProfile.InstanceProfileName
+		// Get Roles
+		if len(respInstanceProfile.InstanceProfile.Roles) > 0 {
+			//ListRolePolicies
+			for _, role := range respInstanceProfile.InstanceProfile.Roles {
+				policyList, err := Sdk.IAM.ListRolePolicies(&iam.ListRolePoliciesInput{
+					RoleName: role.RoleName,
+				})
+				if err != nil {
+					return nil, nil, err
+				}
+				//Here we add the role to InstanceProfile
+				iamrole := &IAMRole{
+					Shared: Shared{
+						Tags: map[string]string{
+							"Name":              r.Name,
+							"KubernetesCluster": immutable.Name,
+						},
+						Name: *role.RoleName,
+					},
+				}
+				newResource.Role = iamrole
+
+				for _, policyName := range policyList.PolicyNames {
+					policyOutput, err := Sdk.IAM.GetRolePolicy(&iam.GetRolePolicyInput{
+						PolicyName: policyName,
+						RoleName:   role.RoleName,
+					})
+					if err != nil {
+						return nil, nil, err
+					}
+					//Here we add the policy to the role
+					iampolicy := &IAMPolicy{
+						Shared: Shared{
+							Tags: map[string]string{
+								"Name":              r.Name,
+								"KubernetesCluster": immutable.Name,
+							},
+							Name: *policyOutput.PolicyName,
+						},
+					}
+					raw, err := url.QueryUnescape(*policyOutput.PolicyDocument)
+					if err != nil {
+						return nil, nil, err
+					}
+					iampolicy.Document = raw
+					iamrole.Policies = append(iamrole.Policies, iampolicy)
+				}
+			}
+		}
+	}
+	newCluster := r.immutableRender(newResource, immutable)
+	return newCluster, newResource, nil
+}
+
+func (r *InstanceProfile) Expected(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resource, error) {
+	logger.Debug("instanceprofile.Expected %v", r.Name)
+	newResource := &InstanceProfile{
+		Shared: Shared{
+			Tags: map[string]string{
+				"Name":              r.Name,
+				"KubernetesCluster": immutable.Name,
+			},
+			Name:       r.Name,
+			Identifier: r.Identifier,
+		},
+		ServerPool: r.ServerPool,
+		Role: &IAMRole{
+			Shared: Shared{
+				Name: r.Role.Name,
+				Tags: map[string]string{
+					"Name":              r.Name,
+					"KubernetesCluster": immutable.Name,
+				},
+			},
+			Policies: []*IAMPolicy{},
+		},
+	}
+	for _, policy := range r.Role.Policies {
+		newPolicy := &IAMPolicy{
+			Shared: Shared{
+				Name: policy.Name,
+				Tags: map[string]string{
+					"Name":              r.Name,
+					"KubernetesCluster": immutable.Name,
+				},
+			},
+			Document: policy.Document,
+		}
+		newResource.Role.Policies = append(newResource.Role.Policies, newPolicy)
+	}
+	newCluster := r.immutableRender(newResource, immutable)
+	return newCluster, newResource, nil
+}
+
+func (r *InstanceProfile) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resource, error) {
+	logger.Debug("instanceprofile.Apply")
+	applyResource := expected.(*InstanceProfile)
+	isEqual, err := compare.IsEqual(actual.(*InstanceProfile), expected.(*InstanceProfile))
+	if err != nil {
+		return nil, nil, err
+	}
+	if isEqual {
+		return immutable, applyResource, nil
+	}
+	logger.Debug("Actual: %#v", actual)
+	logger.Debug("Expectd: %#v", expected)
+	newResource := &InstanceProfile{}
+	//TODO fill in instanceprofile attributes
+
+	// Create InstanceProfile
+	profileinput := &iam.CreateInstanceProfileInput{
+		InstanceProfileName: &expected.(*InstanceProfile).Name,
+		Path:                S("/"),
+	}
+	outInstanceProfile, err := Sdk.IAM.CreateInstanceProfile(profileinput)
+	if err != nil {
+		logger.Debug("CreateInstanceProfile error: %v", err)
+		if err.(awserr.Error).Code() != iam.ErrCodeEntityAlreadyExistsException {
+			return nil, nil, err
+		}
+	}
+	newResource.Name = *outInstanceProfile.InstanceProfile.InstanceProfileName
+	newResource.Identifier = *outInstanceProfile.InstanceProfile.InstanceProfileName
+	logger.Info("InstanceProfile created: %s", newResource.Name)
+	// Create role
+	assumeRolePolicy := `{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]}`
+	roleinput := &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: &assumeRolePolicy,
+		RoleName:                 &expected.(*InstanceProfile).Role.Name,
+		Description:              S("Kubicorn Role"),
+		Path:                     S("/"),
+	}
+	outInstanceRole, err := Sdk.IAM.CreateRole(roleinput)
+	if err != nil {
+		logger.Debug("CreateRole error: %v", err)
+		if err.(awserr.Error).Code() != iam.ErrCodeEntityAlreadyExistsException {
+			return nil, nil, err
+		}
+	}
+	newIamRole := &IAMRole{
+		Shared: Shared{
+			Name: *outInstanceRole.Role.RoleName,
+			Tags: map[string]string{
+				"Name":              r.Name,
+				"KubernetesCluster": immutable.Name,
+			},
+		},
+		Policies: []*IAMPolicy{},
+	}
+	logger.Info("Role created")
+	//Attach Policy to Role
+	for _, policy := range expected.(*InstanceProfile).Role.Policies {
+		policyinput := &iam.PutRolePolicyInput{
+			PolicyDocument: &policy.Document,
+			PolicyName:     &policy.Name,
+			RoleName:       &expected.(*InstanceProfile).Role.Name,
+		}
+		_, err := Sdk.IAM.PutRolePolicy(policyinput)
+		if err != nil {
+			logger.Debug("PutRolePolicy error: %v", err)
+			if err.(awserr.Error).Code() != iam.ErrCodeLimitExceededException {
+				return nil, nil, err
+			}
+		}
+		newPolicy := &IAMPolicy{
+			Shared: Shared{
+				Name: policy.Name,
+				Tags: map[string]string{
+					"Name":              r.Name,
+					"KubernetesCluster": immutable.Name,
+				},
+			},
+			Document: policy.Document,
+		}
+		newIamRole.Policies = append(newIamRole.Policies, newPolicy)
+		logger.Info("Policy created")
+	}
+	//Attach Role to Profile
+	roletoprofile := &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: &expected.(*InstanceProfile).Name,
+		RoleName:            &expected.(*InstanceProfile).Role.Name,
+	}
+	_, err = Sdk.IAM.AddRoleToInstanceProfile(roletoprofile)
+	if err != nil {
+		logger.Debug("AddRoleToInstanceProfile error: %v", err)
+		if err.(awserr.Error).Code() != iam.ErrCodeLimitExceededException {
+			return nil, nil, err
+		}
+	}
+	newResource.Role = newIamRole
+	logger.Info("RoleAttachedToInstanceProfile done")
+	//Add ServerPool
+	newResource.ServerPool = expected.(*InstanceProfile).ServerPool
+	newCluster := r.immutableRender(newResource, immutable)
+	return newCluster, newResource, nil
+}
+
+func (r *InstanceProfile) Delete(actual cloud.Resource, immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resource, error) {
+	for _, policy := range r.Role.Policies {
+		_, err := Sdk.IAM.DeleteRolePolicy(&iam.DeleteRolePolicyInput{
+			PolicyName: &policy.Name,
+			RoleName:   &r.Role.Name,
+		})
+		if err != nil {
+			logger.Debug("Problem deleting Policy %s for Role: %s: %v", policy.Name, r.Role.Name, err)
+			if err.(awserr.Error).Code() != iam.ErrCodeNoSuchEntityException {
+				return nil, nil, err
+			}
+		}
+	}
+	_, err := Sdk.IAM.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: &r.Name,
+		RoleName:            &r.Role.Name,
+	})
+	if err != nil {
+		logger.Debug("Problem remove Role %s from InstanceProfile %s: %v", r.Role.Name, r.Name, err)
+		if err.(awserr.Error).Code() != iam.ErrCodeNoSuchEntityException {
+			return nil, nil, err
+		}
+	}
+	_, err = Sdk.IAM.DeleteRole(&iam.DeleteRoleInput{
+		RoleName: &r.Role.Name,
+	})
+	if err != nil {
+		logger.Debug("Problem delete role %s: %v", r.Role.Name, err)
+		if err.(awserr.Error).Code() != iam.ErrCodeNoSuchEntityException {
+			return nil, nil, err
+		}
+	}
+	_, err = Sdk.IAM.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
+		InstanceProfileName: &r.Name,
+	})
+	if err != nil {
+		logger.Debug("Problem delete InstanceProfile %s: %v", r.Name, err)
+		if err.(awserr.Error).Code() != iam.ErrCodeNoSuchEntityException {
+			return nil, nil, err
+		}
+	}
+	newResource := &InstanceProfile{}
+	newCluster := r.immutableRender(newResource, immutable)
+	logger.Info("Deleted InstanceProfile: %v", r.Name)
+	return newCluster, newResource, nil
+}
+
+func (r *InstanceProfile) immutableRender(newResource cloud.Resource, inaccurateCluster *cluster.Cluster) *cluster.Cluster {
+	logger.Debug("instanceprofile.Render")
+	newCluster := defaults.NewClusterDefaults(inaccurateCluster)
+	instanceProfile := &cluster.IAMInstanceProfile{}
+	instanceProfile.Name = newResource.(*InstanceProfile).Name
+	instanceProfile.Identifier = newResource.(*InstanceProfile).Identifier
+	instanceProfile.Role = &cluster.IAMRole{}
+	if newResource.(*InstanceProfile).Role != nil {
+		instanceProfile.Role.Name = newResource.(*InstanceProfile).Role.Name
+		if len(newResource.(*InstanceProfile).Role.Policies) > 0 {
+			for i := range newResource.(*InstanceProfile).Role.Policies {
+				newPolicy := &cluster.IAMPolicy{
+					Name:       newResource.(*InstanceProfile).Role.Policies[i].Name,
+					Identifier: newResource.(*InstanceProfile).Role.Policies[i].Identifier,
+					Document:   newResource.(*InstanceProfile).Role.Policies[i].Document,
+				}
+				instanceProfile.Role.Policies = append(instanceProfile.Role.Policies, newPolicy)
+			}
+		}
+	}
+	found := false
+	for i := 0; i < len(newCluster.ServerPools); i++ {
+		if newResource.(*InstanceProfile).ServerPool != nil && newCluster.ServerPools[i].Name == newResource.(*InstanceProfile).ServerPool.Name {
+			newCluster.ServerPools[i].InstanceProfile = instanceProfile
+			found = true
+		}
+	}
+	if !found {
+		logger.Debug("Not found ServerPool for InstanceProfile!")
+	}
+	return newCluster
+}

--- a/cloud/amazon/public/resources/instanceprofile.go
+++ b/cloud/amazon/public/resources/instanceprofile.go
@@ -1,3 +1,17 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (

--- a/cloud/amazon/public/resources/launchconfiguration.go
+++ b/cloud/amazon/public/resources/launchconfiguration.go
@@ -39,6 +39,7 @@ type Lc struct {
 	InstanceType     string
 	Image            string
 	SpotPrice        string
+	InstanceProfile  string
 	ServerPool       *cluster.ServerPool
 	BootstrapScripts []string
 }
@@ -74,6 +75,9 @@ func (r *Lc) Actual(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resourc
 			newResource.SpotPrice = *lc.SpotPrice
 		}
 		newResource.Identifier = *lc.LaunchConfigurationName
+		if lc.IamInstanceProfile != nil {
+			newResource.InstanceProfile = *lc.IamInstanceProfile
+		}
 		newResource.Tags = map[string]string{
 			"Name":              r.Name,
 			"KubernetesCluster": immutable.Name,
@@ -81,7 +85,7 @@ func (r *Lc) Actual(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resourc
 	} else {
 		newResource.Image = r.ServerPool.Image
 		newResource.InstanceType = r.ServerPool.Size
-		if r.ServerPool.Type == cluster.ServerPoolTypeNode && r.ServerPool.AwsConfiguration != nil {
+		if r.ServerPool.Type == cluster.ServerPoolTypeNode {
 			newResource.SpotPrice = r.ServerPool.AwsConfiguration.SpotPrice
 		}
 	}
@@ -106,7 +110,10 @@ func (r *Lc) Expected(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resou
 		Image:            r.ServerPool.Image,
 		BootstrapScripts: r.ServerPool.BootstrapScripts,
 	}
-	if r.ServerPool.Type == cluster.ServerPoolTypeNode && r.ServerPool.AwsConfiguration != nil {
+	if r.ServerPool.InstanceProfile != nil {
+		newResource.InstanceProfile = r.ServerPool.InstanceProfile.Name
+	}
+	if r.ServerPool.Type == cluster.ServerPoolTypeNode {
 		newResource.SpotPrice = r.ServerPool.AwsConfiguration.SpotPrice
 	}
 	newCluster := r.immutableRender(newResource, immutable)
@@ -123,6 +130,8 @@ func (r *Lc) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster) 
 	if isEqual {
 		return immutable, applyResource, nil
 	}
+	logger.Debug("Actual: %#v", actual)
+	logger.Debug("Expectd: %#v", expected)
 	var sgs []*string
 	found := false
 	for _, serverPool := range immutable.ServerPools {
@@ -208,26 +217,39 @@ func (r *Lc) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster) 
 		SecurityGroups:           sgs,
 		UserData:                 &b64data,
 	}
-
+	if expected.(*Lc).InstanceProfile != "" {
+		lcInput.IamInstanceProfile = &expected.(*Lc).InstanceProfile
+	}
 	spotPrice, err := strconv.ParseFloat(*&expected.(*Lc).SpotPrice, 64)
 	if *&expected.(*Lc).InstanceType != cluster.ServerPoolTypeMaster && err == nil && spotPrice > 0 {
 		lcInput.SpotPrice = &expected.(*Lc).SpotPrice
 	}
-	_, err = Sdk.ASG.CreateLaunchConfiguration(lcInput)
-	if err != nil {
-		if awserr, ok := err.(awserr.Error); ok {
-			switch awserr.Code() {
-			case autoscaling.ErrCodeAlreadyExistsFault:
-				logger.Debug(autoscaling.ErrCodeAlreadyExistsFault, awserr.Error())
-			case autoscaling.ErrCodeLimitExceededFault:
-				logger.Debug(autoscaling.ErrCodeLimitExceededFault, awserr.Error())
-			case autoscaling.ErrCodeResourceContentionFault:
-				logger.Debug(autoscaling.ErrCodeResourceContentionFault, awserr.Error())
-			default:
-				logger.Debug(awserr.Error())
+	//Make it repeatable due to InstanceProfile
+	for i := 0; i < 10; i++ {
+		_, err = Sdk.ASG.CreateLaunchConfiguration(lcInput)
+		if err != nil {
+			if awserr, ok := err.(awserr.Error); ok {
+				switch awserr.Code() {
+				case autoscaling.ErrCodeAlreadyExistsFault:
+					logger.Debug(autoscaling.ErrCodeAlreadyExistsFault, awserr.Error())
+				case autoscaling.ErrCodeLimitExceededFault:
+					logger.Debug(autoscaling.ErrCodeLimitExceededFault, awserr.Error())
+				case autoscaling.ErrCodeResourceContentionFault:
+					logger.Debug(autoscaling.ErrCodeResourceContentionFault, awserr.Error())
+				default:
+					logger.Debug(awserr.Error())
+				}
+			} else {
+				logger.Debug(err.Error())
 			}
+			if strings.Contains(err.Error(), "Invalid IamInstanceProfile") {
+				logger.Debug("InstanceProfile missing waiting...")
+				time.Sleep(time.Duration(i) * time.Second)
+				continue
+			}
+
 		} else {
-			logger.Debug(err.Error())
+			break
 		}
 		return nil, nil, err
 	}
@@ -237,6 +259,7 @@ func (r *Lc) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster) 
 	newResource.Name = expected.(*Lc).Name
 	newResource.Identifier = expected.(*Lc).Name
 	newResource.BootstrapScripts = r.ServerPool.BootstrapScripts
+	newResource.InstanceProfile = expected.(*Lc).InstanceProfile
 
 	newCluster := r.immutableRender(newResource, immutable)
 	return newCluster, newResource, nil
@@ -267,6 +290,7 @@ func (r *Lc) Delete(actual cloud.Resource, immutable *cluster.Cluster) (*cluster
 	newResource.Image = actual.(*Lc).Image
 	newResource.InstanceType = actual.(*Lc).InstanceType
 	newResource.BootstrapScripts = actual.(*Lc).BootstrapScripts
+	newResource.InstanceProfile = actual.(*Lc).InstanceProfile
 
 	newCluster := r.immutableRender(newResource, immutable)
 	return newCluster, newResource, nil

--- a/cloud/amazon/public/resources/launchconfiguration.go
+++ b/cloud/amazon/public/resources/launchconfiguration.go
@@ -39,6 +39,7 @@ type Lc struct {
 	InstanceType     string
 	Image            string
 	SpotPrice        string
+	InstanceProfile  string
 	ServerPool       *cluster.ServerPool
 	BootstrapScripts []string
 }
@@ -74,6 +75,9 @@ func (r *Lc) Actual(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resourc
 			newResource.SpotPrice = *lc.SpotPrice
 		}
 		newResource.Identifier = *lc.LaunchConfigurationName
+		if lc.IamInstanceProfile != nil {
+			newResource.InstanceProfile = *lc.IamInstanceProfile
+		}
 		newResource.Tags = map[string]string{
 			"Name":              r.Name,
 			"KubernetesCluster": immutable.Name,
@@ -106,6 +110,9 @@ func (r *Lc) Expected(immutable *cluster.Cluster) (*cluster.Cluster, cloud.Resou
 		Image:            r.ServerPool.Image,
 		BootstrapScripts: r.ServerPool.BootstrapScripts,
 	}
+	if r.ServerPool.InstanceProfile != nil {
+		newResource.InstanceProfile = r.ServerPool.InstanceProfile.Name
+	}
 	if r.ServerPool.Type == cluster.ServerPoolTypeNode && r.ServerPool.AwsConfiguration != nil {
 		newResource.SpotPrice = r.ServerPool.AwsConfiguration.SpotPrice
 	}
@@ -123,6 +130,8 @@ func (r *Lc) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster) 
 	if isEqual {
 		return immutable, applyResource, nil
 	}
+	logger.Debug("Actual: %#v", actual)
+	logger.Debug("Expectd: %#v", expected)
 	var sgs []*string
 	found := false
 	for _, serverPool := range immutable.ServerPools {
@@ -208,26 +217,39 @@ func (r *Lc) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster) 
 		SecurityGroups:           sgs,
 		UserData:                 &b64data,
 	}
-
+	if expected.(*Lc).InstanceProfile != "" {
+		lcInput.IamInstanceProfile = &expected.(*Lc).InstanceProfile
+	}
 	spotPrice, err := strconv.ParseFloat(*&expected.(*Lc).SpotPrice, 64)
 	if *&expected.(*Lc).InstanceType != cluster.ServerPoolTypeMaster && err == nil && spotPrice > 0 {
 		lcInput.SpotPrice = &expected.(*Lc).SpotPrice
 	}
-	_, err = Sdk.ASG.CreateLaunchConfiguration(lcInput)
-	if err != nil {
-		if awserr, ok := err.(awserr.Error); ok {
-			switch awserr.Code() {
-			case autoscaling.ErrCodeAlreadyExistsFault:
-				logger.Debug(autoscaling.ErrCodeAlreadyExistsFault, awserr.Error())
-			case autoscaling.ErrCodeLimitExceededFault:
-				logger.Debug(autoscaling.ErrCodeLimitExceededFault, awserr.Error())
-			case autoscaling.ErrCodeResourceContentionFault:
-				logger.Debug(autoscaling.ErrCodeResourceContentionFault, awserr.Error())
-			default:
-				logger.Debug(awserr.Error())
+	//Make it repeatable due to InstanceProfile
+	for i := 0; i < 10; i++ {
+		_, err = Sdk.ASG.CreateLaunchConfiguration(lcInput)
+		if err != nil {
+			if awserr, ok := err.(awserr.Error); ok {
+				switch awserr.Code() {
+				case autoscaling.ErrCodeAlreadyExistsFault:
+					logger.Debug(autoscaling.ErrCodeAlreadyExistsFault, awserr.Error())
+				case autoscaling.ErrCodeLimitExceededFault:
+					logger.Debug(autoscaling.ErrCodeLimitExceededFault, awserr.Error())
+				case autoscaling.ErrCodeResourceContentionFault:
+					logger.Debug(autoscaling.ErrCodeResourceContentionFault, awserr.Error())
+				default:
+					logger.Debug(awserr.Error())
+				}
+			} else {
+				logger.Debug(err.Error())
 			}
+			if strings.Contains(err.Error(), "Invalid IamInstanceProfile") {
+				logger.Debug("InstanceProfile missing waiting...")
+				time.Sleep(time.Duration(i) * time.Second)
+				continue
+			}
+
 		} else {
-			logger.Debug(err.Error())
+			break
 		}
 		return nil, nil, err
 	}
@@ -237,6 +259,7 @@ func (r *Lc) Apply(actual, expected cloud.Resource, immutable *cluster.Cluster) 
 	newResource.Name = expected.(*Lc).Name
 	newResource.Identifier = expected.(*Lc).Name
 	newResource.BootstrapScripts = r.ServerPool.BootstrapScripts
+	newResource.InstanceProfile = expected.(*Lc).InstanceProfile
 
 	newCluster := r.immutableRender(newResource, immutable)
 	return newCluster, newResource, nil
@@ -267,6 +290,7 @@ func (r *Lc) Delete(actual cloud.Resource, immutable *cluster.Cluster) (*cluster
 	newResource.Image = actual.(*Lc).Image
 	newResource.InstanceType = actual.(*Lc).InstanceType
 	newResource.BootstrapScripts = actual.(*Lc).BootstrapScripts
+	newResource.InstanceProfile = actual.(*Lc).InstanceProfile
 
 	newCluster := r.immutableRender(newResource, immutable)
 	return newCluster, newResource, nil

--- a/cloud/atomic_reconciler.go
+++ b/cloud/atomic_reconciler.go
@@ -82,6 +82,7 @@ func (r *AtomicReconciler) cleanUp(failedCluster *cluster.Cluster, i int) (err e
 			continue
 		}
 	}
+	teardown()
 	return nil
 }
 
@@ -130,6 +131,7 @@ func (r *AtomicReconciler) Reconcile(actual, expected *cluster.Cluster) (reconci
 var destroyRetryStrings = []string{
 	"DependencyViolation:",
 	"does not exist in default VPC",
+	"must remove roles from instance profile first",
 }
 
 var hg = &hang.Hanger{
@@ -152,13 +154,22 @@ func (r *AtomicReconciler) Destroy() (destroyedCluster *cluster.Cluster, err err
 	destroyedCluster = defaults.NewClusterDefaults(r.known)
 	for i := len(r.model.Resources()) - 1; i >= 0; i-- {
 		resource := r.model.Resources()[i]
+		logger.Debug("Start deleting resource...")
 		_, actualResource, err := resource.Actual(r.known)
 		if err != nil {
-			i, err = destroyI(err, i)
-			if err != nil {
-				return nil, err
+			//TODO find proper solution resource based
+			logger.Warning("Found error at delete: ", err.Error())
+			skip := false
+			for _, s := range []string{"Found [0]"} {
+				if strings.Contains(err.Error(), s) {
+					logger.Warning("We didn't found the resource so we are skipping it...")
+					skip = true
+					break
+				}
 			}
-			continue
+			if skip {
+				continue
+			}
 		}
 		newCluster, _, err := resource.Delete(actualResource, destroyedCluster)
 		if err != nil {

--- a/profiles/amazon/ubuntu_16_04.go
+++ b/profiles/amazon/ubuntu_16_04.go
@@ -56,6 +56,39 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 				BootstrapScripts: []string{
 					"bootstrap/amazon_k8s_ubuntu_16.04_master.sh",
 				},
+				InstanceProfile: &cluster.IAMInstanceProfile{
+					Name: fmt.Sprintf("%s-KubicornMasterInstanceProfile", name),
+					Role: &cluster.IAMRole{
+						Name: fmt.Sprintf("%s-KubicornMasterRole", name),
+						Policies: []*cluster.IAMPolicy{
+							{
+								Name: "MasterPolicy",
+								Document: `{
+								  "Version": "2012-10-17",
+								  "Statement": [
+									 {
+										"Effect": "Allow",
+										"Action": [
+										   "ec2:*",
+										   "elasticloadbalancing:*",
+										   "ecr:GetAuthorizationToken",
+										   "ecr:BatchCheckLayerAvailability",
+										   "ecr:GetDownloadUrlForLayer",
+										   "ecr:GetRepositoryPolicy",
+										   "ecr:DescribeRepositories",
+										   "ecr:ListImages",
+										   "ecr:BatchGetImage",
+										   "autoscaling:DescribeAutoScalingGroups",
+										   "autoscaling:UpdateAutoScalingGroup"
+										],
+										"Resource": "*"
+									 }
+								  ]
+								}`,
+							},
+						},
+					},
+				},
 				Subnets: []*cluster.Subnet{
 					{
 						Name: fmt.Sprintf("%s.master", name),


### PR DESCRIPTION
Add InstanceProfile feature for AWS. This enables Kubernetes features like: Automatic ELB allocation, PVC handling, etc.  

This is part of #418. 

- New model element: InstanceProfile
- New resource element: InstanceProfile
- Supports Add/Delete/Update InstanceProfile
- Add InstanceProfile to LaunchConfiguration if present
- Manage InstanceProfile - Role - Policy together
- Add Cloud specific configuration to Bootstrap scripts