### PR TITLE
Clean Up Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,15 @@ Please use the `check-headers` make target or run scripts/check-header.sh to val
 
 The `update-headers` make target or scripts/headers.sh will add the necessary headers.
 
-### Vendorning
+### Vendoring
 
-`kubicorn` project uses [`dep`](https://github.com/golang/dep) to manage its dependencies. Before using it, you need to setup it by following the [Setup guide](https://github.com/golang/dep#setup).
+The `kubicorn` project uses [`dep`](https://github.com/golang/dep) to manage its dependencies. Before using it, you need to set it up by following the [Setup guide](https://github.com/golang/dep#setup).
 
-To add new dependency, you need to use:
+To add a new dependency, you need to use:
 ```
 dep ensure import-path
 ```
-If you want to update existing dependency, you need to use:
+If you want to update an existing dependency, you need to use:
 ```
 dep ensure -update import-path
 ```

--- a/apis/README.md
+++ b/apis/README.md
@@ -21,4 +21,4 @@ There are several stakeholders in the open source community coming together to c
 
 Kubicorn will use this in the future.
 
-More information can be found here at [github.com/kris-nova/cluster-api](https://github.com/kris-nova/cluster-api)
+More information can be found at [github.com/kris-nova/cluster-api](https://github.com/kris-nova/cluster-api)

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -4,7 +4,7 @@ These are the bootstrap scripts that ship with the default `kubicorn` profiles.
 
 Feel free to add your own, or modify these at any time.
 
-The scripts are effectively what we use as `user data` to init a VM
+The scripts are effectively what we use as `user data` to initialize a VM
 
 ### I need to template out one of these bootstrap scripts
 

--- a/docs/_documentation/aws-walkthrough.md
+++ b/docs/_documentation/aws-walkthrough.md
@@ -33,6 +33,8 @@ Verify that `kubicorn create` did a good job by executing:
 $ cat _state/myfirstk8s/cluster.yaml
 ```
 
+Feel free to tweak the configuration to your liking here.
+
 #### Authenticating
 
 We're now in a position to have the cluster resources defined, locally, based on the selected profile.

--- a/docs/_documentation/azure-walkthrough.md
+++ b/docs/_documentation/azure-walkthrough.md
@@ -17,7 +17,7 @@ $ go get github.com/kris-nova/kubicorn
 
 The first thing you will do now is to define the cluster resources.
 For this, you need to select a certain profile. Of course, once you're more familiar with `kubicorn`, you can go ahead and extend existing profiles or create new ones.
-In the following we'll be using an existing profile called `do`, which is a profile for a cluster in DigitalOcean.
+In the following we'll be using an existing profile called `azure`, which is a profile for a cluster in Azure.
 
 #### Creating
 
@@ -38,7 +38,7 @@ Feel free to tweak the configuration to your liking here.
 #### Authenticating
 
 Some work will be needed to configure your system to authenticate with `kubicorn`.
-Please spend some time and go through each step carefully to ensure your configuration work correctly.
+Please spend some time and go through each step carefully to ensure your configuration works correctly.
 
 ##### Manually using the Azure CLI tool
 

--- a/docs/_documentation/build.md
+++ b/docs/_documentation/build.md
@@ -20,7 +20,7 @@ Set `GOPATH` in your bash profile:
 $ export GOPATH=/Users/<your user>/go
 $ export PATH=$GOPATH/bin:$PATH
 ```
-You can add these two lines to `~/.bash_profile` to make sure these variables are always.
+You can add these two lines to `~/.bash_profile` to make sure these variables are always set.
 
 If you have this you should be able to run the following command:
 
@@ -29,7 +29,7 @@ $ go get github.com/kris-nova/kubicorn
 ```
 
 ### Building
-Now you can run `make` from the src directory of `kubicorn`:
+Now you can run `make` from the `src` directory of `kubicorn`:
 
 ```bash
 $ cd $GOPATH/src/github.com/kris-nova/kubicorn/
@@ -67,7 +67,7 @@ Keep in mind that other branches might have different dependencies that will nee
 As a simple alternative there is a script located in the Docker folder name "build.sh". 
 This can be used to build Kubicorn without the need to setup a golang environment on your local machine.
 You will need to have Docker installed on your development environment.
-This script should work on any platform that support Docker.
+This script should work on any platform that supports Docker.
 Have a look at the [official Docker documentation](https://docs.docker.com/engine/installation/.) on how to install Docker for your platform of choice.
 
 To use this script just make a git checkout of the `kubicorn` repository and run the build.sh:

--- a/docs/_documentation/google-walkthrough.md
+++ b/docs/_documentation/google-walkthrough.md
@@ -18,7 +18,7 @@ $ go get github.com/kris-nova/kubicorn
 
 The first thing you will do now is to define the cluster resources.
 For this, you need to select a certain profile. Of course, once you're more familiar with `kubicorn`, you can go ahead and extend existing profiles or create new ones.
-In the following we'll be using an existing profile called `do`, which is a profile for a cluster in Google.
+In the following we'll be using an existing profile called `google`, which is a profile for a cluster in Google.
 
 #### Creating
 
@@ -58,7 +58,7 @@ $ ls -al ~/.ssh/id_rsa.pub
 -rw-------@ 1 mhausenblas  staff   754B 20 Mar 04:03 /Users/mhausenblas/.ssh/id_rsa.pub
 ```
 
-Finally, it is necessary to create a firewall rule for allowing ingress traffic to the API server, that is esposed by default on tcp:443 in above profile.
+Finally, it is necessary to create a firewall rule for allowing ingress traffic to the API server, that is exposed by default on tcp:443 in the above profile.
 You can use [this guide to create firewall rules](https://cloud.google.com/compute/docs/vpc/using-firewalls); in production systems,
 it is reccomanded to restrict such firewall rule, limiting the target systems e.g. using network tags, and limiting as well
 the range of allowed source systems.

--- a/docs/_documentation/maintainers.md
+++ b/docs/_documentation/maintainers.md
@@ -16,23 +16,23 @@ doctype: general
  - Strive towards getting `kubicorn` to be production ready.
  - Work with community to:
     - keep the code base stable
-    - code reviews
-    - bug triage
-    - releases
+    - perform code reviews
+    - triage bugs
+    - create releases
     - resolve conflicts
     - research what's best for the community.
  - Work with other maintainers to keep the project growing and stable.
- - Avoid having too many API changes, if necessary it should fullfil [backwards-compatibility-promise](https://github.com/kris-nova/kubicorn/blob/master/docs/SEMVER.md#backwards-compatibility-promise)
+ - Avoid having too many API changes, if necessary it should fulfill [backwards-compatibility-promise](https://github.com/kris-nova/kubicorn/blob/master/docs/SEMVER.md#backwards-compatibility-promise)
  - Don't say Yes unless you are 99.999% (there is nothing 100%).
  - Remember, you are not alone, there are people to help you as well.
  - Take a break, whenever you need.
 
 
 ## Criteria for code merge:
- - Maintainer(s) of the repo can merge code, with atleast 2 LGTM.
+ - Maintainer(s) of the repo can merge code, with at least 2 LGTM.
  - This is mostly Golang code. If golint, gofmt is not done - DON'T merge, follow guidelines here [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments)
  - Look for unit-tests, it is important (try not to merge with TODO unit-test, that just means forget about it).
- - Ofcourse the builds have to be passing.
+ - Of course the builds have to be passing.
 
 ### Current Maintainers:
 - [Kris Nova](https://github.com/kris-nova)

--- a/docs/_documentation/make.md
+++ b/docs/_documentation/make.md
@@ -9,12 +9,12 @@ Run `make help` for command line usage.
 
 ## Prerequisites
 
-To be able to build `kubicorn` using Makefile you need to have configured Go 1.8 environment, which you can set up by following the official [install tutorial](https://golang.org/doc/install).
-Before continuing, make sure that you can use `go` command from your shell.
+To be able to build `kubicorn` using Makefile you need to have a configured Go 1.8 environment, which you can set up by following the official [install tutorial](https://golang.org/doc/install).
+Before continuing, make sure that you can use the `go` command from your shell.
 
 ### Building `kubicorn`
 
-Details about the building proccess can be found in [BUILD docs](https://github.com/kris-nova/kubicorn/blob/master/docs/BUILD.md) and [INSTALL docs](https://github.com/kris-nova/kubicorn/blob/master/docs/INSTALL.md).
+Details about the building process can be found in [BUILD docs](https://github.com/kris-nova/kubicorn/blob/master/docs/BUILD.md) and [INSTALL docs](https://github.com/kris-nova/kubicorn/blob/master/docs/INSTALL.md).
 
 The following `make` commands are available for building `kubicorn`:
 * `make` — parse Bootstrap scripts and create `kubicorn` executable in the `./bin` directory and the `AUTHORS` file.
@@ -25,8 +25,8 @@ The following `make` commands are available for building `kubicorn`:
 
 #### Additional building commands
 
-* `make build-linux-amd64` — create the `kubicorn` executable for Linux 64-bit OS in the `./bin` directory. Requires Docker.
-* `make build-darwin-amd64` — create the `kubicorn` executable for macOS in the `./bin` directory.
+* `make build-linux-amd64` — create the `kubicorn` executable for Linux 64-bit in the `./bin` directory. Requires Docker.
+* `make build-darwin-amd64` — create the `kubicorn` executable for macOS 64-bit in the `./bin` directory.
 * `make build-freebsd-amd64` — create the `kubicorn` executable for FreeBSD 64-bit in the `./bin` directory.
 * `make build-windows-amd64` — create the `kubicorn` executable for Windows 64-bit in the `./bin` directory.
 
@@ -40,9 +40,9 @@ The following `make` commands are available for building `kubicorn`:
 ### Formatting Go code
 
 The following commands can be used to format and verify Go code:
-* `make gofmt` — forma the all Go files using `go fmt`.
+* `make gofmt` — format all Go files using `go fmt`.
 * `make lint` — check for style mistakes all Go files using `golint`.
-* `make vet` — apply `go vet` to the all Go files.
+* `make vet` — apply `go vet` to all Go files.
 
 ### Testing
 

--- a/docs/_documentation/readme.md
+++ b/docs/_documentation/readme.md
@@ -7,27 +7,27 @@ doctype: general
 
 ## Introduction
 
-This document explains how `kubicorn` project works, the project's structure and information you need to know so you can easily start contributing.
+This document explains how the `kubicorn` project works, the project's structure and information you need to know so you can easily start contributing.
 
 ## Glossary
 
 This chapter explains the most important concepts.
 
-* [Cluster API](https://github.com/kris-nova/kubicorn/tree/master/apis) — universal (cloud provider agnostic) representation of a Kubernetes cluster. It defines every part of an cluster, including infrastructure parts such as virtual machines, networking units and firewalls. The matching of universal representation of the cluster to the representation for specific cloud provider is done as the part of Reconciling process.
-* [State](https://github.com/kris-nova/kubicorn/blob/master/state/README.md) — representation of an specific Kubernetes cluster. It's used in reconciling process to create the cluster.
+* [Cluster API](https://github.com/kris-nova/kubicorn/tree/master/apis) — universal (cloud provider agnostic) representation of a Kubernetes cluster. It defines every part of a cluster, including infrastructure parts such as virtual machines, networking units and firewalls. The matching of universal representation of the cluster to the representation for specific cloud provider is done as part of reconciling process.
+* [State](https://github.com/kris-nova/kubicorn/blob/master/state/README.md) — representation of an specific Kubernetes cluster. It's used in the reconciling process to create the cluster.
 * [State store](https://github.com/kris-nova/kubicorn/blob/master/state/README.md) — place where state is stored. Currently, we only support states located on the disk and in [YAML](https://github.com/kris-nova/kubicorn/tree/master/state/fs) or [JSON](https://github.com/kris-nova/kubicorn/tree/master/state/jsonfs) format. We're looking forward to implementing Git and S3 state stores.
 * [Reconciler](https://github.com/kris-nova/kubicorn/tree/master/cloud) — the core of the project and place where provision logic is located. It matches cloud provider agnostic Cluster definition to the specific cloud provider definition, which is used to provision cluster. It takes care of provisioning new clusters, destroying the old ones and keeping the consistency between Actual and Expected states.
 * Actual state — the representation of current resources in the cloud.
 * Expected state — the representation of intended resources in the cloud.
 * [Bootstrap scripts](https://github.com/kris-nova/kubicorn/tree/master/bootstrap) — Bootstrap scripts are provided as the `user data` on the cluster creation to install dependencies and create the cluster. They're provided as Bash scripts, so you can easily create them without Go knowledge. You can also inject values in the reconciling process, per your needs.
-* [VPN Boostrap scripts](https://github.com/kris-nova/kubicorn/tree/master/bootstrap/vpn) — to improve security of our cluster, we create VPN server on master, and connect every node using it. Some cloud providers, such as DigitalOcean, doesn't provide real private networking between Droplets, so we want master and nodes can only communicate between themselves, and with the Internet only on selected ports.
-* [Profile](https://github.com/kris-nova/kubicorn/blob/master/profiles/README.md) — profile is a unique representation of a cluster written in Go. Profiles containts the all information needed to create an cluster, such as: cluster name, cloud provider, VM size, SSH key, network and firewall configurations...
+* [VPN Boostrap scripts](https://github.com/kris-nova/kubicorn/tree/master/bootstrap/vpn) — to improve security of our cluster, we create a VPN server on master, and connect every node using it. Some cloud providers, such as DigitalOcean, doesn't provide real private networking between Droplets, so we want master and nodes can only communicate between themselves, and with the Internet only on selected ports.
+* [Profile](https://github.com/kris-nova/kubicorn/blob/master/profiles/README.md) — profile is a unique representation of a cluster written in Go. Profiles contain all the information needed to create a cluster, such as: cluster name, cloud provider, VM size, SSH key, network and firewall configurations.
 
 ## Project structure
 
-Project is contained from the several packages. 
+The project is contained in several packages.
 
-The most important package is the [`cloud`](https://github.com/kris-nova/kubicorn/tree/master/cloud) which contains Reconciler interface and Reconciler implementations for each cloud provider. Currently, we have implementations for three cloud providers: [Amazon](https://github.com/kris-nova/kubicorn/tree/master/cloud/amazon), [DigitalOcean](https://github.com/kris-nova/kubicorn/tree/master/cloud/digitalocean), [Google](https://github.com/kris-nova/kubicorn/tree/master/cloud/google) and [Azure in-development](https://github.com/kris-nova/kubicorn/pull/327).
+The most important package is the [`cloud`](https://github.com/kris-nova/kubicorn/tree/master/cloud) package, which contains the Reconciler interface and Reconciler implementations for each cloud provider. Currently, we have implementations for three cloud providers: [Amazon](https://github.com/kris-nova/kubicorn/tree/master/cloud/amazon), [DigitalOcean](https://github.com/kris-nova/kubicorn/tree/master/cloud/digitalocean), [Google](https://github.com/kris-nova/kubicorn/tree/master/cloud/google) and [Azure in-development](https://github.com/kris-nova/kubicorn/pull/327).
 
 The Cluster API is located in the [`apis`](https://github.com/kris-nova/kubicorn/tree/master/apis) package.
 
@@ -39,33 +39,33 @@ State store definitions are located in the [`state`](https://github.com/kris-nov
 
 We have two type of tests — CI tests and E2E tests. CI tests are regular Go tests, while E2E tests are run against real cloud infrastucture and it can cost money. E2E tests are available in the [`test`](https://github.com/kris-nova/kubicorn/tree/master/test) package.
 
-The [`cutil`](https://github.com/kris-nova/kubicorn/tree/master/cutil) directory contains many useful, helper packages which are used to do various tasks, such as: [copy the file from the VM](https://github.com/kris-nova/kubicorn/tree/master/cutil/scp), [create `kubeadm` token](https://github.com/kris-nova/kubicorn/tree/master/cutil/kubeadm), [logger implementation](https://github.com/kris-nova/kubicorn/tree/master/cutil/logger)...
+The [`cutil`](https://github.com/kris-nova/kubicorn/tree/master/cutil) directory contains many useful helper packages which are used to do various tasks, such as: [copy the file from the VM](https://github.com/kris-nova/kubicorn/tree/master/cutil/scp), [create `kubeadm` token](https://github.com/kris-nova/kubicorn/tree/master/cutil/kubeadm), [logger implementation](https://github.com/kris-nova/kubicorn/tree/master/cutil/logger)...
 
-The [`cmd`](https://github.com/kris-nova/kubicorn/tree/master/cmd) package is the CLI implementation for `kubicorn`. We use [`cobra`](https://github.com/spf13/cobra) package to create the CLI.
+The [`cmd`](https://github.com/kris-nova/kubicorn/tree/master/cmd) package is the CLI implementation for `kubicorn`. We use [`cobra`](https://github.com/spf13/cobra) to create the CLI.
 
 ## Reconciler
 
 This part of the document will try to summarize what steps are being taken in the reconciling process and how it works.
 
-When you want to create a Kubernetes cluster, you're providing [Cluster API](https://github.com/kris-nova/kubicorn/tree/master/apis) representation of an cluster in form of the [Profile](https://github.com/kris-nova/kubicorn/blob/master/profiles/README.md).
+When you want to create a Kubernetes cluster, you're providing [Cluster API](https://github.com/kris-nova/kubicorn/tree/master/apis) representation of a cluster in form of the [Profile](https://github.com/kris-nova/kubicorn/blob/master/profiles/README.md).
 
-The first task of Reconciler is to convert universal, cloud-provider agnostic representation of an cluster to representation for specific cloud provider. This transition is called **rendering** and is defined in the `model.go` file, as well as in the `immutableRender` function of the cloud-specific Reconciler. For example, this is how [`model.go`](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/model.go) and Droplet's [`immutableRender`](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L305) looks for DigitalOcean.
+The first task of Reconciler is to convert universal, cloud-provider agnostic representation of a cluster to representation for a specific cloud provider. This transition is called **rendering** and is defined in the `model.go` file, as well as in the `immutableRender` function of the cloud-specific Reconciler. For example, this is how [`model.go`](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/model.go) and Droplet's [`immutableRender`](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L305) looks for DigitalOcean.
 
-Once cluster is rendered, we can easily obtain **Expected state** of the cluster using the `Expected` function, which represents what resources we are expecting in the cloud. This is how [`Expected` function](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L92) is defined for DigitalOcean Droplet's.
+Once the cluster is rendered, we can easily obtain **Expected state** of the cluster using the `Expected` function, which represents what resources we are expecting in the cloud. This is how [`Expected` function](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L92) is defined for DigitalOcean Droplets.
 
 Next, Reconciler obtains the **Actual state** using the `Actual ` function, which represents what resources we already have in the cloud. You can take a look at [the following function](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L55), which is used to obtain Actual state of DigitalOcean Droplets.
 
-The most important task of Reconciler is **applying**, using the `Apply` function. Firstly, Reconciler is checking is cluster already existing, by comparing Actual and Expected states, and if yes, it's stopping there returning already existing one. If it doesn't exist, we are proceeding on the creation part, which is consisted of:
+The most important task of Reconciler is **applying**, using the `Apply` function. Firstly, Reconciler is checking if a cluster already exists, by comparing Actual and Expected states, and if yes, it's stopping there returning the already existing one. If it doesn't exist, we are proceeding on the creation part, which consists of:
 
-* [Building Bootstrap Scripts and injecting values at the runtime](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L182-#L196),
+* [Building Bootstrap scripts and injecting values at the runtime](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L182-#L196),
 * [Creating the appropriate resources for Master node](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L203-#L227),
 * [Obtaining needed information for Node creation](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L124-L188),
-* Creating Nodes,
+* Creating Nodes.
 * Downloading the `.kubeconfig` file for the cluster from the master node.
 
 At this point, we have fully functional Kubernetes cluster.
 
-Beside creating the cluster, Reconciler also takes care of destroying the cluster, which is done by the `Delete` function. [This is how it looks for DigitalOcean Droplet's](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L247).
+Besides creating the cluster, Reconciler also takes care of destroying the cluster, which is done by the `Delete` function. [This is how it looks for DigitalOcean Droplets](https://github.com/kris-nova/kubicorn/blob/master/cloud/digitalocean/droplet/resources/droplet.go#L247).
 
 ## Website
 
@@ -79,7 +79,7 @@ Below are the relevant bits of the website's structure. Other files can be ignor
 kubicorn/docs/
 │
 ├── _documentation/
-│ → All docs to be displayed on in the Documentation section of the website
+│ → All docs to be displayed in the Documentation section of the website
 │   should go here. They should be markdown, and include the YAML header as
 │   shown in the link above.
 │
@@ -116,9 +116,9 @@ kubicorn/docs/
 
 ## Where should I start?
 
-If you need more help understanding the reconciling process, take a look at the [examples](https://github.com/kris-nova/kubicorn/tree/master/examples). It should explain you which steps are taken to create a Kubernetes cluster.
+If you need more help understanding the reconciling process, take a look at the [examples](https://github.com/kris-nova/kubicorn/tree/master/examples). It should explain which steps are taken to create a Kubernetes cluster.
 
-To be able to better understand how project works, you should read Reconciler part of this document and follow the links to see how code looks like.
+To be able to better understand how the project works, you should read the [Reconciler](#reconciler) part of this document and follow the links to see how the code looks.
 
 Once you get familiar with the process, find the issue you want to work on.
 
@@ -126,10 +126,10 @@ Our [issue tracker](https://github.com/kris-nova/kubicorn/issues) has every issu
 
 If you're new to the project, we recommend taking a look at [Hacktoberfest](https://github.com/kris-nova/kubicorn/labels/Hacktoberfest)-tagged issues. You can learn more about [Hacktoberfest on its official website](https://hacktoberfest.digitalocean.com/).
 
-Beside Hacktoberfest label, you can filter by the following labels:
+Besides the Hacktoberfest label, you can filter by the following labels:
 
 * [Help (small)](https://github.com/kris-nova/kubicorn/labels/Help%20%28small%29) -- containing issues which shouldn't require a lot of effort to be addressed.
-* [Help (medium)](https://github.com/kris-nova/kubicorn/labels/Help%20%28medium%29) -- issues that could require you medium amount of time to get it addressed.
+* [Help (medium)](https://github.com/kris-nova/kubicorn/labels/Help%20%28medium%29) -- issues that could require you a medium amount of time to get it addressed.
 * [Help (hard)](https://github.com/kris-nova/kubicorn/labels/Help%20%28large%29) -- issues that require a lot of effort to get addressed.
 
 We also label our issue per Cloud provider, operating system and type of the problem.

--- a/docs/_documentation/semver.md
+++ b/docs/_documentation/semver.md
@@ -7,21 +7,21 @@ doctype: general
 
 This document is a work in progress. 
 The backwards compatibility promise will start as of version 1.0.0.
-Before this version new release can break backwards compatibility.
+Before this version new releases can break backwards compatibility.
 
 ## Semver
 
 `kubicorn` follows [Semantic Versioning 2.0.0](http://semver.org/) when creating new releases. 
 In short, this means that we will only break backwards compatibility when doing major releases (such as 1.0, 2.0 etc).
 When releasing minor (such as 1.1.0, 1.2.0, etc) or patch (such as 1.0.1, 1.2.8, etc) updates no backward compatibility will be broken. 
-Its important to us that `kubicorn` keeps working as expected when updating you release between patches and updates. 
-If any backwards compatibility is broken in a release, other then a major release, this will be rectified in a new update.
+It's important to us that `kubicorn` keeps working as expected when updating your release between patches and updates. 
+If any backwards compatibility is broken in a release, other than a major release, this will be rectified in a new update.
 
 ## Release types
-Semantic Versioning has three specific type of releases that `kubicorn` will use:
-* Major (1.0, 2.0 etc): A major release can contain feature and bug fixes. 
+Semantic Versioning has three specific types of releases that `kubicorn` will use:
+* Major (1.0, 2.0 etc): A major release can contain features and bug fixes. 
 These features and bug fixes can break backwards compatibility. 
-Always read the supplied documentation then performing a major upgrade.  
+Always read the supplied documentation before performing a major upgrade.  
 * Minor (1.1.0, 1.2.0, etc): A minor release can contain features and bug fixes. 
 These features and bug fixes are not allowed to break backwards compatibility.
 * Patch (1.0.1, 1.2.8, etc): A patch release can only contain bug fixes. 
@@ -48,5 +48,5 @@ A major release can be released without breaking backwards compatibility.
 
 Releases can contain experimental features. 
 These experimental features are excluded from the backwards compatibility promise. 
-These features will marked as such to prevent confusion. 
+These features will be marked as such to prevent confusion. 
 Experimental features will not invalidate the backwards compatibility promise of existing features.

--- a/test/README.md
+++ b/test/README.md
@@ -3,7 +3,7 @@
 The e2e tests are designed to introduce confidence that `kubicorn` is working as expected. 
 We use the infrastructure testing suite [charlie](https://github.com/kris-nova/charlie) to test our infrastructure.
 
-At this time e2e tests are not ran automatically for CI, but rather ran ad-hoc until we can harden our process. 
+At this time e2e tests are not run automatically for CI, but rather ran ad-hoc until we can harden our process. 
 All cloud credentials will need to be valid, and set in order to run the e2e tests. 
 You can find out more about which environmental variables need to be set in the [environmental variables cheat sheet](../docs/envar.md).
 


### PR DESCRIPTION
applies to docs and all package READMEs

- Cleans up grammar and spelling errors.
- Makes 'Creating' section for aws consistent with others
- Fixes profile name errors in azure and google walthroughs

closes #473 