### PR TITLE
Adding IAM profile for node group and fixing kubelet service restart

### DIFF
--- a/bootstrap/amazon_k8s_ubuntu_16.04_node.sh
+++ b/bootstrap/amazon_k8s_ubuntu_16.04_node.sh
@@ -25,5 +25,8 @@ systemctl start docker
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDMASTER')
 
+systemctl daemon-reload
+systemctl restart kubelet.service
+
 kubeadm reset
 kubeadm join --token ${TOKEN} ${MASTER}

--- a/profiles/amazon/ubuntu_16_04.go
+++ b/profiles/amazon/ubuntu_16_04.go
@@ -139,7 +139,7 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 						Name: fmt.Sprintf("%s-KubicornNodeRole", name),
 						Policies: []*cluster.IAMPolicy{
 							{
-								Name: "MasterPolicy",
+								Name: "NodePolicy",
 								Document: `{
 								  "Version": "2012-10-17",
 								  "Statement": [

--- a/profiles/amazon/ubuntu_16_04.go
+++ b/profiles/amazon/ubuntu_16_04.go
@@ -133,6 +133,38 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 				BootstrapScripts: []string{
 					"bootstrap/amazon_k8s_ubuntu_16.04_node.sh",
 				},
+				InstanceProfile: &cluster.IAMInstanceProfile{
+					Name: fmt.Sprintf("%s-KubicornNodeInstanceProfile", name),
+					Role: &cluster.IAMRole{
+						Name: fmt.Sprintf("%s-KubicornNodeRole", name),
+						Policies: []*cluster.IAMPolicy{
+							{
+								Name: "MasterPolicy",
+								Document: `{
+								  "Version": "2012-10-17",
+								  "Statement": [
+									 {
+										"Effect": "Allow",
+										"Action": [
+										   "ec2:Describe*",
+										   "ecr:GetAuthorizationToken",
+										   "ecr:BatchCheckLayerAvailability",
+										   "ecr:GetDownloadUrlForLayer",
+										   "ecr:GetRepositoryPolicy",
+										   "ecr:DescribeRepositories",
+										   "ecr:ListImages",
+										   "ecr:BatchGetImage",
+										   "autoscaling:DescribeAutoScalingGroups",
+										   "autoscaling:UpdateAutoScalingGroup"
+										],
+										"Resource": "*"
+									 }
+								  ]
+								}`,
+							},
+						},
+					},
+				},
 				Subnets: []*cluster.Subnet{
 					{
 						Name: fmt.Sprintf("%s.node", name),


### PR DESCRIPTION
This is related to the previous IAM support #472 PR. Contains a fix and an example of an AWS profile for Ubuntu.