### PR TITLE
Document necessary IAM permissions for AWS

### DIFF
--- a/docs/_documentation/aws-walkthrough.md
+++ b/docs/_documentation/aws-walkthrough.md
@@ -43,6 +43,8 @@ You might want to create a new [IAM user](http://docs.aws.amazon.com/IAM/latest/
 
 ![AWS IAM permissions required for `kubicorn`](https://github.com/kris-nova/kubicorn/raw/master/docs/img/aws-iam-user-perm-screen-shot.png){:class="img-fluid"}
 
+If you would like to apply a more restrictive IAM policy to your AWS kubicorn user, take a look at the [explicit list](http://kubicorn.io/documentation/minimal-aws-permissions.html) of actions used.
+
 Next, you need to specify your AWS credentials to use - you can select one of the follwoing options 
 
  * Environment Credentials - export the two environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` so that `kubicorn` can pick it up in the next step:
@@ -81,6 +83,7 @@ You can now `kubectl get nodes` and verify that Kubernetes 1.7.0 is now running.
 You can also `ssh` into your instances using the example command found in the output from `kubicorn`
 
 ![AWS IAM permissions required for `kubicorn`](https://github.com/kris-nova/kubicorn/raw/master/docs/img/aws-example-apply.png){:class="img-fluid"}
+
 
 #### Deleting
 

--- a/docs/_documentation/minimal-aws-permissions.md
+++ b/docs/_documentation/minimal-aws-permissions.md
@@ -1,0 +1,69 @@
+---
+layout: documentation
+title: Minimal AWS IAM Permissions
+date: 2017-11-13
+doctype: aws
+---
+
+Should you wish to use a minimal set of AWS IAM permissions for your Kubicorn cluster (e.g., running as part of a continuous integration system for testing), you can use the following AWS profile.
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": {
+        "Effect": "Allow",
+        "Action": [
+            "autoscaling:CreateAutoScalingGroup",
+            "autoscaling:CreateLaunchConfiguration",
+            "autoscaling:CreateOrUpdateTags",
+            "autoscaling:DeleteAutoScalingGroup",
+            "autoscaling:DeleteLaunchConfiguration",
+            "autoscaling:DescribeAutoScalingGroups",
+            "autoscaling:DescribeLaunchConfigurations",
+            "autoscaling:UpdateAutoScalingGroup",
+            "ec2:AssociateRouteTable",
+            "ec2:AttachInternetGateway",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CreateInternetGateway",
+            "ec2:CreateRoute",
+            "ec2:CreateRouteTable",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateSubnet",
+            "ec2:CreateTags",
+            "ec2:CreateVpc",
+            "ec2:DeleteInternetGateway",
+            "ec2:DeleteRouteTable",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DeleteSubnet",
+            "ec2:DeleteTags",
+            "ec2:DeleteVpc",
+            "ec2:DescribeInstances",
+            "ec2:DescribeInternetGateways",
+            "ec2:DescribeRouteTables",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcs",
+            "ec2:DetachInternetGateway",
+            "ec2:DisassociateRouteTable",
+            "ec2:ImportKeyPair",
+            "ec2:ModifyVpcAttribute",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances",
+            "iam:AddRoleToInstanceProfile",
+            "iam:CreateInstanceProfile",
+            "iam:CreateRole",
+            "iam:DeleteInstanceProfile",
+            "iam:DeleteInstanceProfile",
+            "iam:DeleteRole",
+            "iam:DeleteRolePolicy",
+            "iam:GetInstanceProfile",
+            "iam:GetRolePolicy",
+            "iam:ListRolePolicies",
+            "iam:PassRole",
+            "iam:PutRolePolicy",
+            "iam:RemoveRoleFromInstanceProfile"
+        ],
+        "Resource": "*"
+    }
+}
+```


### PR DESCRIPTION
This set of actions is the minimum required for kubicorn to work on AWS,
in case users don't want to give their IAM user wide permissions.