### PR TITLE
cloud/README.txt with text from project walkthrough

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,1 +1,19 @@
-# Reconciler
+The `cloud` package contains the Reconciler interface and Reconciler implementations for each cloud provider.
+
+The tasks covered in this package include
+
+* *rendering* a universial, cloud-provider agnostic cluster representation into a representation for a specific cloud provider
+* obtaining the *expected* state of the cluster
+* obtaining the *actual* state of the cluster
+* comparing *expected* and *actual* and *applying* changes
+
+The *Apply* function does most of the work, including
+
+* Building Bootstrap scripts and injecting values at the runtime
+* Creating the appropriate resources for Master node
+* Obtaining needed information for Node creation
+* Creating Nodes
+* Downloading the .kubeconfig file for the cluster from the master node
+
+See the [Kubicorn project walkthrough](http://kubicorn.io/documentation/readme.html) for a more detailed account of these components and how they interrelate.
+

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -2,7 +2,7 @@ The `cloud` package contains the Reconciler interface and Reconciler implementat
 
 The tasks covered in this package include
 
-* *rendering* a universial, cloud-provider agnostic cluster representation into a representation for a specific cloud provider
+* *rendering* a universal, cloud-provider agnostic cluster representation into a representation for a specific cloud provider
 * obtaining the *expected* state of the cluster
 * obtaining the *actual* state of the cluster
 * comparing *expected* and *actual* and *applying* changes


### PR DESCRIPTION
See #480 

This new readme incorporates a concise view of the `cloud` package and the Reconciler interface, and refers to the Kubicorn project walkthrough for details.

It does not yet have a "how to add a new cloud" detailed description, though it's a step towards that direction.