### PR TITLE
Pass in host user/group ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ gofmt: install-tools
 build-linux-amd64: ## Create the kubicorn executable for Linux 64-bit OS in the ./bin directory. Requires Docker.
 	mkdir -p bin
 	docker run \
+	-u $$(id -u):$$(id -g) \
 	-it \
 	-w /go/src/github.com/kris-nova/kubicorn \
 	-v ${PWD}:/go/src/github.com/kris-nova/kubicorn \


### PR DESCRIPTION
When building kubicorn on CI systems, it's helpful for the resulting
binary to be owned by the CI user, so that it can be deleted during
clean up without permission issues. Pass in the current user/group
ID to Docker to facilitate this.

It is not passed in to the shell target, as the user is almost
guaranteed to not exist on the image, and a valid user should be present
when working in the shell.