### PR TITLE
Ensure linux-amd64 build is statically linked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-linux-amd64: ## Create the kubicorn executable for Linux 64-bit OS in the 
 	--rm golang:1.8.1 make docker-build-linux-amd64
 
 docker-build-linux-amd64:
-	go build -v -o bin/linux-amd64
+	CGO_ENABLED=0 go build -v -o bin/linux-amd64
 
 build-darwin-amd64: ## Create the kubicorn executable for Darwin (osX) 64-bit OS in the ./bin directory. Requires Docker.
 	GOOS=darwin GOARCH=amd64 go build -v -o bin/darwin-amd64 &


### PR DESCRIPTION
By default, the docker image is linking Kubicorn against musl. This
causes the user.Current function to be marked as unimplemented on a host
without musl. Set CGO_ENABLED=0 on the make target to ensure it's always
statically linked.

Test with both `make build-linux-amd64` and `docker/build.sh --make=docker-build-linux-amd64`

Looking at the binary before this change:
```
x1c in /home/nrb/go/src/github.com/kris-nova/kubicorn (git) static-link-linux-amd64 U
% file bin/linux-amd64
bin/linux-amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, with debug_info, not stripped


x1c in /home/nrb/go/src/github.com/kris-nova/kubicorn (git) static-link-linux-amd64 U
% readelf -a bin/linux-amd64 | grep libc
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
readelf: bin/linux-amd64: Warning: local symbol 0 found at index >= .dynsym's sh_info value of 0
  0x0030: Version: 1  File: libc.so.6  Cnt: 1
```

And after
```
x1c in /home/nrb/go/src/github.com/kris-nova/kubicorn (git) static-link-linux-amd64 U
% readelf -a bin/linux-amd64 | grep libc

x1c in /home/nrb/go/src/github.com/kris-nova/kubicorn (git) static-link-linux-amd64 U
% file bin/linux-amd64
bin/linux-amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped
```

