### PR TITLE
Moved the sighandler from init to reconcile state handlers, fixing th…

### DIFF
--- a/cloud/atomic_reconciler.go
+++ b/cloud/atomic_reconciler.go
@@ -43,6 +43,8 @@ func NewAtomicReconciler(known *cluster.Cluster, model Model) Reconciler {
 }
 
 func (r *AtomicReconciler) Actual(known *cluster.Cluster) (actualCluster *cluster.Cluster, err error) {
+	initSignal()
+	defer teardown()
 	actualCluster = defaults.NewClusterDefaults(r.known)
 	for i := 0; i < len(r.model.Resources()); i++ {
 		resource := r.model.Resources()[i]
@@ -55,6 +57,8 @@ func (r *AtomicReconciler) Actual(known *cluster.Cluster) (actualCluster *cluste
 }
 
 func (r *AtomicReconciler) Expected(known *cluster.Cluster) (expectedCluster *cluster.Cluster, err error) {
+	initSignal()
+	defer teardown()
 	expectedCluster = defaults.NewClusterDefaults(r.known)
 	for i := 0; i < len(r.model.Resources()); i++ {
 		resource := r.model.Resources()[i]
@@ -67,6 +71,8 @@ func (r *AtomicReconciler) Expected(known *cluster.Cluster) (expectedCluster *cl
 }
 
 func (r *AtomicReconciler) cleanUp(failedCluster *cluster.Cluster, i int) (err error) {
+	initSignal()
+	defer teardown()
 	logger.Warning("")
 	logger.Warning("Attempting to backtrack and cleanup created resources.")
 	logger.Warning("")
@@ -82,14 +88,14 @@ func (r *AtomicReconciler) cleanUp(failedCluster *cluster.Cluster, i int) (err e
 			continue
 		}
 	}
-	teardown()
 	return nil
 }
 
 var createdResources = make(map[int]Resource)
 
 func (r *AtomicReconciler) Reconcile(actual, expected *cluster.Cluster) (reconciledCluster *cluster.Cluster, err error) {
-
+	initSignal()
+	defer teardown()
 	reconciledCluster = defaults.NewClusterDefaults(r.known)
 	for i := 0; i < len(r.model.Resources()); i++ {
 		if sigHandler.GetState() != 0 {
@@ -124,7 +130,6 @@ func (r *AtomicReconciler) Reconcile(actual, expected *cluster.Cluster) (reconci
 		reconciledCluster = newCluster
 		createdResources[i] = appliedResource
 	}
-	teardown()
 	return reconciledCluster, nil
 }
 
@@ -151,6 +156,8 @@ func destroyI(err error, i int) (int, error) {
 }
 
 func (r *AtomicReconciler) Destroy() (destroyedCluster *cluster.Cluster, err error) {
+	initSignal()
+	defer teardown()
 	destroyedCluster = defaults.NewClusterDefaults(r.known)
 	for i := len(r.model.Resources()) - 1; i >= 0; i-- {
 		resource := r.model.Resources()[i]
@@ -181,11 +188,10 @@ func (r *AtomicReconciler) Destroy() (destroyedCluster *cluster.Cluster, err err
 		}
 		destroyedCluster = newCluster
 	}
-	teardown()
 	return destroyedCluster, nil
 }
 
-func init() {
+func initSignal() {
 	sigHandler = signals.NewSignalHandler(600)
 	sigHandler.Register()
 }


### PR DESCRIPTION
…e 10m exit if nothing happens after start. When using as a package it's extremely annoying that if there is no calls towards the reconciler Kubiciorn exits (the main app as well).