### PR TITLE
signals: fix reconciler panics

### DIFF
--- a/cloud/amazon/public/resources/instanceprofile.go
+++ b/cloud/amazon/public/resources/instanceprofile.go
@@ -15,6 +15,8 @@
 package resources
 
 import (
+	"net/url"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/kris-nova/kubicorn/apis/cluster"
@@ -22,7 +24,6 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/compare"
 	"github.com/kris-nova/kubicorn/cutil/defaults"
 	"github.com/kris-nova/kubicorn/cutil/logger"
-	"net/url"
 )
 
 var _ cloud.Resource = &InstanceProfile{}

--- a/cloud/atomic_reconciler.go
+++ b/cloud/atomic_reconciler.go
@@ -36,7 +36,6 @@ type AtomicReconciler struct {
 }
 
 func NewAtomicReconciler(known *cluster.Cluster, model Model) Reconciler {
-
 	return &AtomicReconciler{
 		known: known,
 		model: model,
@@ -192,6 +191,7 @@ func (r *AtomicReconciler) Destroy() (destroyedCluster *cluster.Cluster, err err
 	return destroyedCluster, nil
 }
 
+// TODO(@xmudrii): improve implementation of sighandlers
 func initSignal() {
 	sigHandler = signals.NewSignalHandler(600)
 	sigHandler.Register()
@@ -200,4 +200,5 @@ func initSignal() {
 func teardown() {
 	logger.Debug("Resetting TimeOut counter.")
 	sigHandler.Reset()
+	sigHandler = nil
 }

--- a/cutil/signals/signals.go
+++ b/cutil/signals/signals.go
@@ -70,7 +70,9 @@ func (h *Handler) GetState() int {
 }
 
 func (h *Handler) Reset() {
-	h.timer.Stop()
+	if h != nil && h.timer != nil {
+		h.timer.Stop()
+	}
 }
 
 // Register starts handling signals.


### PR DESCRIPTION
This PR hotfixes panics due to dereferencing nil pointer.

Currently, applying a cluster will result in panic:
```
marko@Marko:~$ kubicorn apply testcluster
2017-11-26T10:22:01+01:00 [ℹ]  Selected [fs] state store
2017-11-26T10:22:01+01:00 [ℹ]  Loaded cluster: testcluster
2017-11-26T10:22:01+01:00 [ℹ]  Init Cluster
2017-11-26T10:22:01+01:00 [ℹ]  Query existing resources
2017-11-26T10:22:04+01:00 [ℹ]  Resolving expected resources
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x489222]

goroutine 1 [running]:
time.(*Timer).Stop(0x0, 0x11d8c40)
        /usr/local/go/src/time/sleep.go:75 +0x22
github.com/kris-nova/kubicorn/cutil/signals.(*Handler).Reset(0xc4202eef80)
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/cutil/signals/signals.go:73 +0x2f
github.com/kris-nova/kubicorn/cloud.teardown()
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/cloud/atomic_reconciler.go:205 +0x7b
github.com/kris-nova/kubicorn/cloud.(*AtomicReconciler).Expected(0xc420199420, 0xc4203de820, 0xc4203dfd40, 0x0, 0x0)
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/cloud/atomic_reconciler.go:70 +0x33c
github.com/kris-nova/kubicorn/cmd.RunApply(0x19da540, 0x11d97c0, 0xee5fe0)
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/cmd/apply.go:150 +0x6e2
github.com/kris-nova/kubicorn/cmd.ApplyCmd.func1(0xc420222d80, 0xc420278e90, 0x1, 0x1)
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/cmd/apply.go:60 +0x72
github.com/kris-nova/kubicorn/vendor/github.com/spf13/cobra.(*Command).execute(0xc420222d80, 0xc420278e50, 0x1, 0x1, 0xc420222d80, 0xc420278e50)
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/vendor/github.com/spf13/cobra/command.go:653 +0x2a2
github.com/kris-nova/kubicorn/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x19d3c60, 0xe01269, 0x119c5d9, 0x4)
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/vendor/github.com/spf13/cobra/command.go:728 +0x2fe
github.com/kris-nova/kubicorn/vendor/github.com/spf13/cobra.(*Command).Execute(0x19d3c60, 0x0, 0x9bb)
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/vendor/github.com/spf13/cobra/command.go:687 +0x2b
github.com/kris-nova/kubicorn/cmd.Execute()
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/cmd/root.go:85 +0x31
main.main()
        /mnt/d/Projects/Go/src/github.com/kris-nova/kubicorn/main.go:22 +0x20
```

I think this behavior started as of PR #487.