### PR TITLE
Fix apt order in packet bootstrap files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Peter Smeets <p.e.smeets@gmail.com>
 Prateek Gogia <pgogia@varmour.com>
 Prateek Gogia <prateekgogia@hotmail.com>
 Robert Bailey <robertbailey@google.com>
+S.Çağlar Onur <caglar@digitalocean.com>
 Steven Klassen <sklassen@gmail.com>
 Ted Wood <ted@xy0.org>
 William Stewart <zoidbergwill@gmail.com>

--- a/bootstrap/packet_k8s_ubuntu_16.04_master.sh
+++ b/bootstrap/packet_k8s_ubuntu_16.04_master.sh
@@ -4,12 +4,21 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
+# order is important:
+# 1. update
+# 2. install apt-transport-https
+# 3. add kubernetes repos to list
+# 4. update again
+# 5. install
+apt-get update -y
+apt-get install -y apt-transport-https
+
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 touch /etc/apt/sources.list.d/kubernetes.list
-sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+sh -c 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
 
-apt-get install apt-transport-https
 apt-get update -y
+
 apt-get install -y \
     socat \
     ebtables \

--- a/bootstrap/packet_k8s_ubuntu_16.04_node.sh
+++ b/bootstrap/packet_k8s_ubuntu_16.04_node.sh
@@ -4,12 +4,22 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
+
+# order is important:
+# 1. update
+# 2. install apt-transport-https
+# 3. add kubernetes repos to list
+# 4. update again
+# 5. install
+apt-get update -y
+apt-get install -y apt-transport-https
+
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 touch /etc/apt/sources.list.d/kubernetes.list
-sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+sh -c 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
 
-apt-get install apt-transport-https
 apt-get update -y
+
 apt-get install -y \
     socat \
     ebtables \


### PR DESCRIPTION
The apt install order worked ok on x86, but did not on arm. This fixes the install order of `apt` packages universally.

A future PR will complete arm work (everything works except for a Calico issue).