### PR TITLE
new cluster annotation for kubeconfig local path

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kris-nova/kubicorn/cutil/agent"
 	"github.com/kris-nova/kubicorn/cutil/initapi"
 	"github.com/kris-nova/kubicorn/cutil/kubeconfig"
+	"github.com/kris-nova/kubicorn/cutil/local"
 	"github.com/kris-nova/kubicorn/cutil/logger"
 	"github.com/kris-nova/kubicorn/state"
 	"github.com/kris-nova/kubicorn/state/fs"
@@ -191,6 +192,11 @@ func RunApply(options *ApplyOptions) error {
 	}
 
 	logger.Always("The [%s] cluster has applied successfully!", newCluster.Name)
+	if path, ok := newCluster.Annotations[kubeconfig.ClusterAnnotationKubeconfigLocalFile]; ok {
+		path = local.Expand(path)
+		logger.Always("To start using your cluster, you need to run")
+		logger.Always("  export KUBECONFIG=\"${KUBECONFIG}:%s\"", path)
+	}
 	logger.Always("You can now `kubectl get nodes`")
 	privKeyPath := strings.Replace(cluster.SSH.PublicKeyPath, ".pub", "", 1)
 	logger.Always("You can SSH into your cluster ssh -i %s %s@%s", privKeyPath, newCluster.SSH.User, newCluster.KubernetesAPI.Endpoint)

--- a/cutil/defaults/defaults.go
+++ b/cutil/defaults/defaults.go
@@ -14,10 +14,16 @@
 
 package defaults
 
-import "github.com/kris-nova/kubicorn/apis/cluster"
+import (
+	"github.com/kris-nova/kubicorn/apis/cluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func NewClusterDefaults(base *cluster.Cluster) *cluster.Cluster {
 	new := &cluster.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: base.ObjectMeta.Annotations,
+		},
 		Name:          base.Name,
 		CloudId:       base.CloudId,
 		Cloud:         base.Cloud,


### PR DESCRIPTION
Kubicorn by default appends to `~/.kube/.config` the kubeconfig file for newly created clusters.

This behaviours is more than fine when you work mainly with only one cluster, but it creates some problems when you work with many clusters at the same time (as reported in [#496](https://github.com/kris-nova/kubicorn/issues/496)).

This PR introduces a new alpha annotation at cluster level,  `cluster.alpha.kubicorn.io/kubeconfig-local-path`.

By setting this annotation in your cluster state, the kubeconfig file is saved instead in the specified path, allowing user to switch to one cluster to another e.g. by setting the `KUBENCOFIG` env var.

