### PR TITLE
Allow nodes to manage EC2 volumes

### DIFF
--- a/profiles/amazon/ubuntu_16_04.go
+++ b/profiles/amazon/ubuntu_16_04.go
@@ -147,6 +147,8 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 										"Effect": "Allow",
 										"Action": [
 										   "ec2:Describe*",
+										   "ec2:AttachVolume",
+										   "ec2:DetachVolume",
 										   "ecr:GetAuthorizationToken",
 										   "ecr:BatchCheckLayerAvailability",
 										   "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
In order for containers on nodes to use dynamic PVs, the nodes need to
have the permission to attach and detach volumes. The master has
"ec2:*", and thus doesn't need these permissions explicitly.