### PR TITLE
Allow CentOS nodes to manage EBS volumes

### DIFF
--- a/profiles/amazon/centos_7.go
+++ b/profiles/amazon/centos_7.go
@@ -147,6 +147,8 @@ func NewCentosCluster(name string) *cluster.Cluster {
 										"Effect": "Allow",
 										"Action": [
 										   "ec2:Describe*",
+										   "ec2:AttachVolume",
+										   "ec2:DetachVolume",
 										   "ecr:GetAuthorizationToken",
 										   "ecr:BatchCheckLayerAvailability",
 										   "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
PR #507 only updated the Ubuntu profile. This updates CentOS as well.