### PR TITLE
cmd: implement explain command

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -106,6 +106,7 @@ func RunApply(options *cli.ApplyOptions) error {
 		}
 	}
 
+	logger.Info("Init Cluster")
 	cluster, err = initapi.InitCluster(cluster)
 	if err != nil {
 		return err

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -119,6 +119,7 @@ func RunEdit(options *cli.EditOptions) error {
 		return err
 	}
 
+	logger.Info("Init Cluster")
 	cluster, err = initapi.InitCluster(cluster)
 	if err != nil {
 		os.Remove(fpath)

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -46,7 +46,7 @@ type OutputData struct {
 
 var exo = &ExplainOptions{}
 
-// ListCmd represents the list command
+// ExpalinCmd represents the explain command
 func ExplainCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "explain",

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -46,7 +46,7 @@ type OutputData struct {
 
 var exo = &ExplainOptions{}
 
-// ExpalinCmd represents the explain command
+// ExplainCmd represents the explain command
 func ExplainCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "explain",

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -1,0 +1,164 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/kris-nova/kubicorn/apis/cluster"
+	"github.com/kris-nova/kubicorn/cutil"
+	"github.com/kris-nova/kubicorn/cutil/initapi"
+
+	"github.com/kris-nova/kubicorn/cutil/logger"
+	"github.com/kris-nova/kubicorn/state"
+	"github.com/kris-nova/kubicorn/state/fs"
+	"github.com/kris-nova/kubicorn/state/git"
+	"github.com/kris-nova/kubicorn/state/jsonfs"
+	"github.com/spf13/cobra"
+	gg "github.com/tcnksm/go-gitconfig"
+)
+
+type ExplainOptions struct {
+	Options
+	Profile string
+	Output  string
+}
+
+type OutputData struct {
+	Actual   *cluster.Cluster
+	Expected *cluster.Cluster
+}
+
+var exo = &ExplainOptions{}
+
+// ListCmd represents the list command
+func ExplainCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "explain",
+		Short: "Explain cluster",
+		Long:  `Output expected and actual state of the given cluster`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				exo.Name = strEnvDef("KUBICORN_NAME", "")
+			} else if len(args) > 1 {
+				logger.Critical("Too many arguments.")
+				os.Exit(1)
+			} else {
+				exo.Name = args[0]
+			}
+
+			err := RunExplain(exo)
+			if err != nil {
+				logger.Critical(err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&exo.StateStore, "state-store", "s", strEnvDef("KUBICORN_STATE_STORE", "fs"), "The state store type to use for the cluster")
+	cmd.Flags().StringVarP(&exo.StateStorePath, "state-store-path", "S", strEnvDef("KUBICORN_STATE_STORE_PATH", "./_state"), "The state store path to use")
+	cmd.Flags().StringVarP(&exo.Output, "output", "o", strEnvDef("KUBICORN_OUTPUT", "json"), "Output format (currently only JSON supported)")
+
+	return cmd
+}
+
+func RunExplain(options *ExplainOptions) error {
+
+	// Ensure we have a name
+	name := options.Name
+	if name == "" {
+		return errors.New("Empty name. Must specify the name of the cluster to apply")
+	}
+
+	// Expand state store path
+	options.StateStorePath = expandPath(options.StateStorePath)
+
+	// Register state store
+	var stateStore state.ClusterStorer
+	switch options.StateStore {
+	case "fs":
+		stateStore = fs.NewFileSystemStore(&fs.FileSystemStoreOptions{
+			BasePath:    options.StateStorePath,
+			ClusterName: name,
+		})
+	case "git":
+		if options.GitRemote == "" {
+			return errors.New("Empty GitRemote url. Must specify the link to the remote git repo.")
+		}
+		user, _ := gg.Global("user.name")
+		email, _ := gg.Email()
+
+		stateStore = git.NewJSONGitStore(&git.JSONGitStoreOptions{
+			BasePath:    options.StateStorePath,
+			ClusterName: name,
+			CommitConfig: &git.JSONGitCommitConfig{
+				Name:   user,
+				Email:  email,
+				Remote: options.GitRemote,
+			},
+		})
+	case "jsonfs":
+		stateStore = jsonfs.NewJSONFileSystemStore(&jsonfs.JSONFileSystemStoreOptions{
+			BasePath:    options.StateStorePath,
+			ClusterName: name,
+		})
+	}
+
+	cluster, err := stateStore.GetCluster()
+	if err != nil {
+		return fmt.Errorf("Unable to get cluster [%s]: %v", name, err)
+	}
+
+	cluster, err = initapi.InitCluster(cluster)
+	if err != nil {
+		return err
+	}
+
+	runtimeParams := &cutil.RuntimeParameters{}
+
+	if len(ao.AwsProfile) > 0 {
+		runtimeParams.AwsProfile = ao.AwsProfile
+	}
+
+	reconciler, err := cutil.GetReconciler(cluster, runtimeParams)
+	if err != nil {
+		return fmt.Errorf("Unable to get reconciler: %v", err)
+	}
+
+	var d OutputData
+	d.Actual, err = reconciler.Actual(cluster)
+	if err != nil {
+		return fmt.Errorf("Unable to get actual cluster: %v", err)
+	}
+	d.Expected, err = reconciler.Expected(cluster)
+	if err != nil {
+		return fmt.Errorf("Unable to get expected cluster: %v", err)
+	}
+
+	if exo.Output == "json" {
+		o, err := json.MarshalIndent(d, "", "\t")
+		if err != nil {
+			return fmt.Errorf("Unable to parse cluster: %v", err)
+		}
+		fmt.Printf("%s\n", o)
+	} else {
+		return fmt.Errorf("Unsupported output format")
+	}
+
+	return nil
+}

--- a/cmd/getconfig.go
+++ b/cmd/getconfig.go
@@ -85,6 +85,7 @@ func RunGetConfig(options *cli.GetConfigOptions) error {
 	}
 	logger.Info("Loaded cluster: %s", cluster.Name)
 
+	logger.Info("Init Cluster")
 	cluster, err = initapi.InitCluster(cluster)
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ func addCommands() {
 	RootCmd.AddCommand(CreateCmd())
 	RootCmd.AddCommand(DeleteCmd())
 	RootCmd.AddCommand(EditCmd())
+	RootCmd.AddCommand(ExplainCmd())
 	RootCmd.AddCommand(GetConfigCmd())
 	RootCmd.AddCommand(ImageCmd())
 	RootCmd.AddCommand(ListCmd())

--- a/docs/_documentation/cloud-providers.md
+++ b/docs/_documentation/cloud-providers.md
@@ -15,7 +15,7 @@ In order to add a new cloud provider, you need to implement several key function
 3. Create a subdirectory in the [profiles directory](https://github.com/kris-nova/kubicorn/tree/master/profiles) named for the provider. The directory name should be the same as the name of the provider from the first step.
 4. Create one or more profiles for the provider in the [profiles directory](https://github.com/kris-nova/kubicorn/tree/master/profiles) for the provider. A profile contains all of the necessary information to create a specific implementation in a given cloud provider, e.g. instance size, ssh key, etc.
 5. Add the implemented profiles as profile options to `profileMapIndexed` in [create.go](https://github.com/kris-nova/kubicorn/blob/master/cmd/create.go). Be sure to `import` the necessary package from `profiles/`
-6. Add the provider as a `known.Cloud` to [reconciler.go](https://github.com/kris-nova/kubicorn/blob/master/cutil/reconciler.go)
+6. Add the provider as a `known.Cloud` to [reconciler.go](https://github.com/kris-nova/kubicorn/blob/master/pkg/reconciler.go)
 7. Add any bootstrap scripts required in [bootstrap/](https://github.com/kris-nova/kubicorn/tree/master/bootstrap/). As a general rule, the name of the script should be `<provider>_k8s_<profile>_master.sh` or `<provider>_k8s_<profile>_node.sh`
 
 ### Profile
@@ -58,7 +58,7 @@ The function should use the `known` parameter to provide profile-specific inform
 
 You can name the function anything you want.
 
-This model factory should be called from within the appropriate provider-specific block in [reconciler.go](https://github.com/kris-nova/kubicorn/blob/master/cutil/reconciler.go). the block is expected to do the following:
+This model factory should be called from within the appropriate provider-specific block in [reconciler.go](https://github.com/kris-nova/kubicorn/blob/master/pkg/reconciler.go). the block is expected to do the following:
 
 1. Initialize any APIs or SDKs necessary.
 2. Call `cloud.NewAtomicReconciler(known, ModelFunc(known))` , where `ModelFunc` is the model function for your cloud provider implementation.

--- a/docs/_documentation/envar.md
+++ b/docs/_documentation/envar.md
@@ -16,6 +16,7 @@ KUBICORN_PROFILE | string | The profile name to create new clusters APIs with
 KUBICORN_SET | string | Set custom property for the cluster
 KUBICORN_TRUECOLOR | bool | Always run `kubicorn` with lolgopher truecolor
 KUBICORN_ENVIRONMENT | string | If it's set to `LOCAL`, `kubicorn` will use bootstrap local bootstrap scripts instead of remote ones. 
+KUBICORN_OUTPUT | string | Set output format for command
 KUBICORN_FORCE_DELETE_KEY | bool | Force delete key for AWS or Packet
 KUBICORN_FORCE_DISABLE_SSH_AGENT | bool | Force SCP and SSH to never use SSH agent
 --- | --- | ---

--- a/examples/amazon/basiccluster.go
+++ b/examples/amazon/basiccluster.go
@@ -23,6 +23,7 @@ import (
 
 func main() {
 	logger.Level = 4
+	logger.Info("Init Cluster")
 	cluster := amazon.NewUbuntuCluster("myCluster")
 	cluster, err := initapi.InitCluster(cluster)
 	if err != nil {

--- a/examples/digitalocean/basiccluster.go
+++ b/examples/digitalocean/basiccluster.go
@@ -23,6 +23,7 @@ import (
 
 func main() {
 	logger.Level = 4
+	logger.Info("Init Cluster")
 	cluster := digitalocean.NewUbuntuCluster("myCluster")
 	cluster, err := initapi.InitCluster(cluster)
 	if err != nil {

--- a/examples/google/compute/basiccluster.go
+++ b/examples/google/compute/basiccluster.go
@@ -23,6 +23,7 @@ import (
 
 func main() {
 	logger.Level = 4
+	logger.Info("Init Cluster")
 	cluster := googlecompute.NewUbuntuCluster("myCluster")
 	cluster, err := initapi.InitCluster(cluster)
 	if err != nil {

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -59,6 +59,13 @@ type ListOptions struct {
 	Profile string
 }
 
+// ExplainOptions represents explain command options.
+type ExplainOptions struct {
+	Options
+	Profile string
+	Output  string
+}
+
 // VersionOptions contains fields for version output
 type VersionOptions struct {
 	Version   string `json:"Version"`

--- a/pkg/initapi/init.go
+++ b/pkg/initapi/init.go
@@ -34,7 +34,6 @@ var validations = []validationFunc{
 }
 
 func InitCluster(initCluster *cluster.Cluster) (*cluster.Cluster, error) {
-	logger.Info("Init Cluster")
 	logger.Debug("Running preprocessors")
 	for _, f := range preProcessors {
 		var err error


### PR DESCRIPTION
Closes #359 

Currently, it only supports JSON format. Once we get this in I'll start working on the textual output as well.

Signed-off-by: Marko Mudrinić <mudrinic.mare@gmail.com>