### PR TITLE
Update Digital Ocean Ubuntu Profile to use k8s 1.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _state*
 .idea*
 .DS_Store
 bin/*
+.vscode

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Avi Deitcher <avi@deitcher.net>
 Bo Ingram <boingram6@gmail.com>
 Brad Pinter <brad.pinter@gmail.com>
 Carolyn Van Slyck <me@carolynvanslyck.com>
+Curtis Schiewek <curtis.schiewek@gmail.com>
 Darron Froese <dfroese@salesforce.com>
 Ellen Körbes <ellenkorbes@gmail.com>
 Eric Hole <eric.hole@gmail.com>

--- a/bootstrap/digitalocean_k8s_ubuntu_16.04_master.sh
+++ b/bootstrap/digitalocean_k8s_ubuntu_16.04_master.sh
@@ -15,7 +15,7 @@ apt-get install -y \
     docker.io \
     apt-transport-https \
     kubelet \
-    kubeadm=1.7.0-00 \
+    kubeadm=1.9.1-00 \
     cloud-utils \
     jq
 

--- a/bootstrap/digitalocean_k8s_ubuntu_16.04_node.sh
+++ b/bootstrap/digitalocean_k8s_ubuntu_16.04_node.sh
@@ -25,4 +25,4 @@ TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDMASTER')
 
 sudo -E kubeadm reset
-sudo -E kubeadm join --token ${TOKEN} ${MASTER}
+sudo -E kubeadm join --discovery-token-unsafe-skip-ca-verification --token ${TOKEN} ${MASTER}

--- a/bootstrap/digitalocean_k8s_ubuntu_16.04_node.sh
+++ b/bootstrap/digitalocean_k8s_ubuntu_16.04_node.sh
@@ -15,7 +15,7 @@ sudo apt-get install -y \
     docker.io \
     apt-transport-https \
     kubelet \
-    kubeadm=1.7.0-00 \
+    kubeadm=1.9.1-00 \
     jq
 
 sudo systemctl enable docker

--- a/cutil/parser/fileresource.go
+++ b/cutil/parser/fileresource.go
@@ -40,12 +40,14 @@ func ReadFromResource(r string) (string, error) {
 
 	case strings.HasPrefix(strings.ToLower(r), "http://") || strings.HasPrefix(strings.ToLower(r), "https://"):
 		url, err := url.ParseRequestURI(r)
+		logger.Info("Parsing bootstrap script from url [%s]", url)
 		if err != nil {
 			return "", err
 		}
 		return readFromHTTP(url)
 
 	default:
+		logger.Info("Parsing bootstrap script from filesystem [%s]", r)
 		return readFromFS(r)
 	}
 }

--- a/cutil/parser/github.go
+++ b/cutil/parser/github.go
@@ -18,7 +18,7 @@ import "fmt"
 
 const (
 	githubProtocol = "https://"
-	githubRepo     = "raw.githubusercontent.com/cschiewek/kubicorn"
+	githubRepo     = "raw.githubusercontent.com/kris-nova/kubicorn"
 	githubBranch   = "master"
 )
 

--- a/cutil/parser/github.go
+++ b/cutil/parser/github.go
@@ -18,7 +18,7 @@ import "fmt"
 
 const (
 	githubProtocol = "https://"
-	githubRepo     = "raw.githubusercontent.com/kris-nova/kubicorn"
+	githubRepo     = "raw.githubusercontent.com/cschiewek/kubicorn"
 	githubBranch   = "master"
 )
 


### PR DESCRIPTION
:wave:

This PR updates the the digital ocean ubuntu bootstrap scripts to install 1.9.1.

I also added some extra logging to the filesource parser, so it's more obvious what bootstrap scripts are running.

I've tested these changes locally and they work 💯.  

I was going to update other profiles, but I currently only have access to Digital Ocean instances. 

Thanks! 