### PR TITLE
digitalocean: rework digitalocean bootstrap scripts

### DIFF
--- a/apis/cluster/cluster.go
+++ b/apis/cluster/cluster.go
@@ -41,6 +41,7 @@ type Cluster struct {
 	Values            *Values        `json:"values,omitempty"`
 	KubernetesAPI     *KubernetesAPI `json:"kubernetesAPI,omitempty"`
 	GroupIdentifier   string         `json:"groupIdentifier,omitempty"`
+	Components        *Components    `json:"components,omitempty"`
 }
 
 func NewCluster(name string) *Cluster {

--- a/apis/cluster/components.go
+++ b/apis/cluster/components.go
@@ -1,0 +1,19 @@
+// Copyright © 2017 The Kubicorn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+type Components struct {
+	ComponentVPN bool `json:"vpn"`
+}

--- a/bootstrap/digitalocean_k8s_centos_7_master.sh
+++ b/bootstrap/digitalocean_k8s_centos_7_master.sh
@@ -4,10 +4,15 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
-sudo rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg
-sudo rpm --import https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.9.2"
+KUBERNETES_CNI="0.6.0"
 
-sudo sh -c 'cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+# Import GPG keys and add repository entries for Kuberenetes.
+rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg
+rpm --import https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes
 baseurl=http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
@@ -16,45 +21,76 @@ gpgcheck=1
 repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-EOF'
+EOF
 
-# SELinux is disabled by default in DO. This is not recommended and will be fixed later.
-
-sudo yum makecache -y
-sudo sudo yum install -y \
+# Install packages.
+yum makecache -y
+yum install -y \
      docker \
      socat \
      ebtables \
-     kubelet \
-     kubeadm \
+     kubelet-${KUBERNETES_VERSION}-0 \
+     kubeadm-${KUBERNETES_VERSION}-0 \
+     kubernetes-cni-${KUBERNETES_CNI}-0 \
      cloud-utils \
      epel-release
 
-# jq needs its own special yum install as it depends on epel-release
+# "jq" depends on epel-release, so it needs its own yum install command.
 sudo yum install -y jq
 
+# Enable Docker and Kubelet services.
 systemctl enable docker
-systemctl enable kubelet.service
+systemctl enable kubelet
 systemctl start docker
 
+# Obtain Droplet IP addresses.
+HOSTNAME=$(curl -s http://169.254.169.254/metadata/v1/hostname)
+PRIVATEIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
 PUBLICIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
 VPNIP=$(ip addr show dev tun0 | awk '/inet / {print $2}' | cut -d"/" -f1)
 echo $VPNIP > /tmp/.ip
 
+# Specify node IP for kubelet.
+echo "Environment=\"KUBELET_EXTRA_ARGS=--node-ip=${PUBLICIP}\"" >> /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+
+# Parse Kubicorn configuration file.
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDTOKEN')
 PORT=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDPORT | tonumber')
 
-# Required by kubeadm
+# Required by kubeadm.
 sysctl -w net.bridge.bridge-nf-call-iptables=1
 sysctl -p
 
+# Create kubeadm configuration file.
+touch /etc/kubicorn/kubeadm-config.yaml
+cat << EOF  > "/etc/kubicorn/kubeadm-config.yaml"
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+token: ${TOKEN}
+kubernetesVersion: ${KUBERNETES_VERSION}
+nodeName: ${HOSTNAME}
+api:
+  advertiseAddress: ${PUBLICIP}
+  bindPort: ${PORT}
+apiServerCertSANs:
+- ${PRIVATEIP}
+- ${PUBLICIP}
+- ${HOSTNAME}
+authorizationModes:
+- Node
+- RBAC
+EOF
+
+# Initialize cluster.
 kubeadm reset
-kubeadm init --apiserver-bind-port ${PORT} --token ${TOKEN}  --apiserver-advertise-address ${PUBLICIP} --apiserver-cert-extra-sans ${PUBLICIP} ${VPNIP}
+kubeadm init --config /etc/kubicorn/kubeadm-config.yaml
 
-kubectl apply \
-  -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml \
-  --kubeconfig /etc/kubernetes/admin.conf
+# Weave CNI plugin.
+curl -SL "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.IPALLOC_RANGE=172.16.6.64/27" \
+| kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f -
 
-# Root
-mkdir -p ~/.kube
-cp /etc/kubernetes/admin.conf ~/.kube/config
+mkdir -p /root/.kube
+cp /etc/kubernetes/admin.conf /root/.kube/config
+chown -R root:root /root/.kube

--- a/bootstrap/digitalocean_k8s_ubuntu_16.04_master.sh
+++ b/bootstrap/digitalocean_k8s_ubuntu_16.04_master.sh
@@ -4,41 +4,76 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.9.2"
+KUBERNETES_CNI="0.6.0"
+
+# Obtain Droplet IP addresses.
+HOSTNAME=$(curl -s http://169.254.169.254/metadata/v1/hostname)
+PRIVATEIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+PUBLICIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+VPNIP=$(ip addr show dev tun0 | awk '/inet / {print $2}' | cut -d"/" -f1)
+echo $VPNIP > /tmp/.ip
+
+# Add Kubernetes repository.
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 touch /etc/apt/sources.list.d/kubernetes.list
 sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
 
+# Install packages.
 apt-get update -y
 apt-get install -y \
     socat \
     ebtables \
     docker.io \
     apt-transport-https \
-    kubelet \
-    kubeadm=1.9.1-00 \
+    kubelet=${KUBERNETES_VERSION}-00 \
+    kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
     cloud-utils \
     jq
 
-
+# Enable and start Docker.
 systemctl enable docker
 systemctl start docker
 
-PUBLICIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
-VPNIP=$(ip addr show dev tun0 | awk '/inet / {print $2}' | cut -d"/" -f1)
-echo $VPNIP > /tmp/.ip
+# Specify node IP for kubelet.
+echo "Environment=\"KUBELET_EXTRA_ARGS=--node-ip=${PUBLICIP}\"" >> /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
 
+# Parse kubicorn configuration file.
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDTOKEN')
 PORT=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDPORT | tonumber')
 
+# Create kubeadm configuration file.
+touch /etc/kubicorn/kubeadm-config.yaml
+cat << EOF  > "/etc/kubicorn/kubeadm-config.yaml"
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+token: ${TOKEN}
+kubernetesVersion: ${KUBERNETES_VERSION}
+nodeName: ${HOSTNAME}
+api:
+  advertiseAddress: ${PUBLICIP}
+  bindPort: ${PORT}
+apiServerCertSANs:
+- ${PRIVATEIP}
+- ${PUBLICIP}
+- ${HOSTNAME}
+authorizationModes:
+- Node
+- RBAC
+EOF
+
+# Initialize cluster.
 kubeadm reset
-kubeadm init --apiserver-bind-port ${PORT} --token ${TOKEN}  --apiserver-advertise-address ${PUBLICIP} --apiserver-cert-extra-sans ${PUBLICIP} ${VPNIP}
+kubeadm init --config /etc/kubicorn/kubeadm-config.yaml
 
+# Weave CNI plugin.
+curl -SL "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.IPALLOC_RANGE=172.16.6.64/27" \
+| kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f -
 
-kubectl apply \
-  -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml \
-  --kubeconfig /etc/kubernetes/admin.conf
-
-# Root
-mkdir -p ~/.kube
-cp /etc/kubernetes/admin.conf ~/.kube/config
-
+mkdir -p /root/.kube
+cp /etc/kubernetes/admin.conf /root/.kube/config
+chown -R root:root /root/.kube

--- a/bootstrap/digitalocean_k8s_ubuntu_16.04_node.sh
+++ b/bootstrap/digitalocean_k8s_ubuntu_16.04_node.sh
@@ -4,25 +4,48 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
-sudo curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-sudo touch /etc/apt/sources.list.d/kubernetes.list
-sudo sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+# Specify the Kubernetes version to use.
+KUBERNETES_VERSION="1.9.2"
+KUBERNETES_CNI="0.6.0"
 
-sudo apt-get update -y
-sudo apt-get install -y \
+# Obtain Droplet IP addresses.
+HOSTNAME=$(curl -s http://169.254.169.254/metadata/v1/hostname)
+PRIVATEIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+PUBLICIP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+VPNIP=$(ip addr show dev tun0 | awk '/inet / {print $2}' | cut -d"/" -f1)
+echo $VPNIP > /tmp/.ip
+
+# Add Kubernetes repository.
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+touch /etc/apt/sources.list.d/kubernetes.list
+sh -c 'echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+
+# Install packages.
+apt-get update -y
+apt-get install -y \
     socat \
     ebtables \
     docker.io \
     apt-transport-https \
-    kubelet \
-    kubeadm=1.9.1-00 \
+    kubelet=${KUBERNETES_VERSION}-00 \
+    kubeadm=${KUBERNETES_VERSION}-00 \
+    kubernetes-cni=${KUBERNETES_CNI}-00 \
+    cloud-utils \
     jq
 
-sudo systemctl enable docker
-sudo systemctl start docker
+# Enable and start Docker.
+systemctl enable docker
+systemctl start docker
 
+# Specify node IP for kubelet.
+echo "Environment=\"KUBELET_EXTRA_ARGS=--node-ip=${PUBLICIP}\"" >> /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl daemon-reload
+systemctl restart kubelet
+
+# Parse kubicorn configuration file.
 TOKEN=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDTOKEN')
 MASTER=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDMASTER')
 
-sudo -E kubeadm reset
-sudo -E kubeadm join --discovery-token-unsafe-skip-ca-verification --token ${TOKEN} ${MASTER}
+# Join node a cluster.
+kubeadm reset
+kubeadm join --node-name ${HOSTNAME} --token ${TOKEN} ${MASTER} --discovery-token-unsafe-skip-ca-verification

--- a/bootstrap/vpn/openvpnMaster-centos.sh
+++ b/bootstrap/vpn/openvpnMaster-centos.sh
@@ -11,108 +11,117 @@ OPENVPN_KEYEMAIL="root@localhost"
 OPENVPN_KEYOU="Kubicorn"
 OPENVPN_KEYNAME="server"
 
-PRIVATE_IP=$(curl http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
-
-# OpenVPN
 yum install epel-release -y
-yum install openvpn easy-rsa -y
+yum install jq -y
 
-mkdir ~/openvpn-ca
-cp -rf /usr/share/easy-rsa/2.0/* ~/openvpn-ca/
+VPN=$(cat /etc/kubicorn/cluster.json | jq -r '.components.vpn')
 
-sed -i -e "s/export KEY_COUNTRY.*/export KEY_COUNTRY=\"${OPENVPN_KEYCOUNTRY}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_PROVINCE.*/export KEY_PROVINCE=\"${OPENVPN_KEYPROVINCE}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_CITY.*/export KEY_CITY=\"${OPENVPN_KEYCITY}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_ORG.*/export KEY_ORG=\"${OPENVPN_KEYORG}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_EMAIL.*/export KEY_EMAIL=\"${OPENVPN_KEYEMAIL}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_OU.*/export KEY_OU=\"${OPENVPN_KEYOU}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_NAME.*/export KEY_NAME=\"${OPENVPN_KEYNAME}\"/" ~/openvpn-ca/vars
+if [ -z $VPN ]; then
+    sleep 7
+    export VPN=$(cat /etc/kubicorn/cluster.json | jq -r '.components.vpn')
+fi
 
-## Generate server certificates
-cd ~/openvpn-ca
-source vars
-./clean-all
-./build-ca --batch
-./build-key-server --batch ${OPENVPN_KEYNAME}
-./build-dh
-openvpn --genkey --secret keys/ta.key
+if $VPN; then
+    PRIVATE_IP=$(curl http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
 
-## Generate client certificates
-./build-key --batch clients
+    # OpenVPN
+    yum install epel-release -y
+    yum install openvpn easy-rsa -y
 
-## Generate OpenVPN configuration
-cp ~/openvpn-ca/keys/ca.crt ~/openvpn-ca/keys/ca.key ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.crt \
-    ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.key ~/openvpn-ca/keys/ta.key ~/openvpn-ca/keys/dh2048.pem /etc/openvpn
-cp /usr/share/doc/openvpn-2.4.3/sample/sample-config-files/server.conf /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    mkdir ~/openvpn-ca
+    cp -rf /usr/share/easy-rsa/2.0/* ~/openvpn-ca/
 
-### Adjust TLS configuration
-sed -i -e "s/\;tls-auth ta.key 0.*/tls-auth ta.key 0/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
-sed -i -e "/tls-auth ta.key 0/a key-direction 0" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "s/export KEY_COUNTRY.*/export KEY_COUNTRY=\"${OPENVPN_KEYCOUNTRY}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_PROVINCE.*/export KEY_PROVINCE=\"${OPENVPN_KEYPROVINCE}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_CITY.*/export KEY_CITY=\"${OPENVPN_KEYCITY}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_ORG.*/export KEY_ORG=\"${OPENVPN_KEYORG}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_EMAIL.*/export KEY_EMAIL=\"${OPENVPN_KEYEMAIL}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_OU.*/export KEY_OU=\"${OPENVPN_KEYOU}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_NAME.*/export KEY_NAME=\"${OPENVPN_KEYNAME}\"/" ~/openvpn-ca/vars
 
-### Enable AES-128-CBC chipers
-sed -i -e "s/\;cipher AES-128-CBC.*/cipher AES-128-CBC/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
-sed -i -e "/cipher AES-128-CBC/a auth SHA256" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    ## Generate server certificates
+    cd ~/openvpn-ca
+    source vars
+    ./clean-all
+    ./build-ca --batch
+    ./build-key-server --batch ${OPENVPN_KEYNAME}
+    ./build-dh
+    openvpn --genkey --secret keys/ta.key
 
-### Set user and group
-sed -i -e "s/\;user nobody.*/user nobody/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
-sed -i -e "s/\;group nogroup.*/group nogroup/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    ## Generate client certificates
+    ./build-key --batch clients
 
-### TODO(xmudrii): find way to generate new cert for every client
-### Enable duplicate certificates
-sed -i -e "s/\;duplicate-cn.*/duplicate-cn/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    ## Generate OpenVPN configuration
+    cp ~/openvpn-ca/keys/ca.crt ~/openvpn-ca/keys/ca.key ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.crt \
+        ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.key ~/openvpn-ca/keys/ta.key ~/openvpn-ca/keys/dh2048.pem /etc/openvpn
+    cp /usr/share/doc/openvpn-2.4.3/sample/sample-config-files/server.conf /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-## Enable IP forwarding
-sed -i -e "s/\#net.ipv4.ip_forward.*/net.ipv4.ip_forward=1/" /etc/sysctl.conf
-sysctl -p
+    ### Adjust TLS configuration
+    sed -i -e "s/\;tls-auth ta.key 0.*/tls-auth ta.key 0/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "/tls-auth ta.key 0/a key-direction 0" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-systemctl start openvpn@${OPENVPN_KEYNAME}
-systemctl enable openvpn@${OPENVPN_KEYNAME}
+    ### Enable AES-128-CBC chipers
+    sed -i -e "s/\;cipher AES-128-CBC.*/cipher AES-128-CBC/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "/cipher AES-128-CBC/a auth SHA256" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-## Generate client configuration
+    ### Set user and group
+    sed -i -e "s/\;user nobody.*/user nobody/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "s/\;group nogroup.*/group nogroup/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-### Create the directory structure and secure it
-mkdir -p ~/client-configs/files
-chmod 700 ~/client-configs/files
+    ### TODO(xmudrii): find way to generate new cert for every client
+    ### Enable duplicate certificates
+    sed -i -e "s/\;duplicate-cn.*/duplicate-cn/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-### Generate config from examples
-cp /usr/share/doc/openvpn-2.4.3/sample/sample-config-files/client.conf ~/client-configs/base.conf
+    ## Enable IP forwarding
+    sed -i -e "s/\#net.ipv4.ip_forward.*/net.ipv4.ip_forward=1/" /etc/sysctl.conf
+    sysctl -p
 
-### Add remote IP address
-sed -i -e "s/remote my-server-1 1194/remote ${PRIVATE_IP} 1194/" ~/client-configs/base.conf
+    systemctl start openvpn@${OPENVPN_KEYNAME}
+    systemctl enable openvpn@${OPENVPN_KEYNAME}
 
-### Set nobody:nogroup to run OpenVPN
-sed -i -e "s/\;user nobody.*/user nobody/" ~/client-configs/base.conf
-sed -i -e "s/\;group nogroup.*/group nogroup/" ~/client-configs/base.conf
+    ## Generate client configuration
 
-### Make it not use default certificate
-sed -i -e "s/ca ca.crt/\#ca ca.crt/" ~/client-configs/base.conf
-sed -i -e "s/cert client.crt/\#cert client.crt/" ~/client-configs/base.conf
-sed -i -e "s/key client.key/\#key client.key/" ~/client-configs/base.conf
+    ### Create the directory structure and secure it
+    mkdir -p ~/client-configs/files
+    chmod 700 ~/client-configs/files
 
-### Configure chipers
-sed -i -e "s/\;cipher x.*/cipher AES-128-CBC/" ~/client-configs/base.conf
-sed -i -e "/cipher AES-128-CBC/a auth SHA256" ~/client-configs/base.conf
+    ### Generate config from examples
+    cp /usr/share/doc/openvpn-2.4.3/sample/sample-config-files/client.conf ~/client-configs/base.conf
 
-### Additional settings
-echo "key-direction 1" >> ~/client-configs/base.conf
-echo "script-security 2" >> ~/client-configs/base.conf
+    ### Add remote IP address
+    sed -i -e "s/remote my-server-1 1194/remote ${PRIVATE_IP} 1194/" ~/client-configs/base.conf
 
-## Generate keys
-KEY_DIR=~/openvpn-ca/keys
-OUTPUT_DIR=/tmp
-BASE_CONFIG=~/client-configs/base.conf
+    ### Set nobody:nogroup to run OpenVPN
+    sed -i -e "s/\;user nobody.*/user nobody/" ~/client-configs/base.conf
+    sed -i -e "s/\;group nogroup.*/group nogroup/" ~/client-configs/base.conf
 
-cat ${BASE_CONFIG} \
-    <(echo -e '<ca>') \
-    ${KEY_DIR}/ca.crt \
-    <(echo -e '</ca>\n<cert>') \
-    ${KEY_DIR}/clients.crt \
-    <(echo -e '</cert>\n<key>') \
-    ${KEY_DIR}/clients.key \
-    <(echo -e '</key>\n<tls-auth>') \
-    ${KEY_DIR}/ta.key \
-    <(echo -e '</tls-auth>') \
-    > ${OUTPUT_DIR}/clients.conf
+    ### Make it not use default certificate
+    sed -i -e "s/ca ca.crt/\#ca ca.crt/" ~/client-configs/base.conf
+    sed -i -e "s/cert client.crt/\#cert client.crt/" ~/client-configs/base.conf
+    sed -i -e "s/key client.key/\#key client.key/" ~/client-configs/base.conf
 
+    ### Configure chipers
+    sed -i -e "s/\;cipher x.*/cipher AES-128-CBC/" ~/client-configs/base.conf
+    sed -i -e "/cipher AES-128-CBC/a auth SHA256" ~/client-configs/base.conf
 
+    ### Additional settings
+    echo "key-direction 1" >> ~/client-configs/base.conf
+    echo "script-security 2" >> ~/client-configs/base.conf
 
+    ## Generate keys
+    KEY_DIR=~/openvpn-ca/keys
+    OUTPUT_DIR=/tmp
+    BASE_CONFIG=~/client-configs/base.conf
+
+    cat ${BASE_CONFIG} \
+        <(echo -e '<ca>') \
+        ${KEY_DIR}/ca.crt \
+        <(echo -e '</ca>\n<cert>') \
+        ${KEY_DIR}/clients.crt \
+        <(echo -e '</cert>\n<key>') \
+        ${KEY_DIR}/clients.key \
+        <(echo -e '</key>\n<tls-auth>') \
+        ${KEY_DIR}/ta.key \
+        <(echo -e '</tls-auth>') \
+        > ${OUTPUT_DIR}/clients.conf
+fi

--- a/bootstrap/vpn/openvpnMaster.sh
+++ b/bootstrap/vpn/openvpnMaster.sh
@@ -11,107 +11,117 @@ OPENVPN_KEYEMAIL="root@localhost"
 OPENVPN_KEYOU="Kubicorn"
 OPENVPN_KEYNAME="server"
 
-PRIVATE_IP=$(curl http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+apt-get update -y
+apt-get install -y jq
 
-# OpenVPN
+VPN=$(cat /etc/kubicorn/cluster.json | jq -r '.components.vpn')
 
-apt-get update
-apt-get install -y openvpn easy-rsa
+if [ -z $VPN ]; then
+    sleep 7
+    export VPN=$(cat /etc/kubicorn/cluster.json | jq -r '.components.vpn')
+fi
 
-make-cadir ~/openvpn-ca
+if $VPN; then
+    PRIVATE_IP=$(curl http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
 
-sed -i -e "s/export KEY_COUNTRY.*/export KEY_COUNTRY=\"${OPENVPN_KEYCOUNTRY}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_PROVINCE.*/export KEY_PROVINCE=\"${OPENVPN_KEYPROVINCE}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_CITY.*/export KEY_CITY=\"${OPENVPN_KEYCITY}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_ORG.*/export KEY_ORG=\"${OPENVPN_KEYORG}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_EMAIL.*/export KEY_EMAIL=\"${OPENVPN_KEYEMAIL}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_OU.*/export KEY_OU=\"${OPENVPN_KEYOU}\"/" ~/openvpn-ca/vars
-sed -i -e "s/export KEY_NAME.*/export KEY_NAME=\"${OPENVPN_KEYNAME}\"/" ~/openvpn-ca/vars
+    # OpenVPN
 
-## Generate server certificates
-cd ~/openvpn-ca
-source vars
-./clean-all
-./build-ca --batch
-./build-key-server --batch ${OPENVPN_KEYNAME}
-./build-dh
-openvpn --genkey --secret keys/ta.key
+    apt-get install -y openvpn easy-rsa
 
-## Generate client certificates
-./build-key --batch clients
+    make-cadir ~/openvpn-ca
 
-## Generate OpenVPN configuration
-cp ~/openvpn-ca/keys/ca.crt ~/openvpn-ca/keys/ca.key ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.crt \
-    ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.key ~/openvpn-ca/keys/ta.key ~/openvpn-ca/keys/dh2048.pem /etc/openvpn
-gunzip -c /usr/share/doc/openvpn/examples/sample-config-files/server.conf.gz | tee /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "s/export KEY_COUNTRY.*/export KEY_COUNTRY=\"${OPENVPN_KEYCOUNTRY}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_PROVINCE.*/export KEY_PROVINCE=\"${OPENVPN_KEYPROVINCE}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_CITY.*/export KEY_CITY=\"${OPENVPN_KEYCITY}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_ORG.*/export KEY_ORG=\"${OPENVPN_KEYORG}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_EMAIL.*/export KEY_EMAIL=\"${OPENVPN_KEYEMAIL}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_OU.*/export KEY_OU=\"${OPENVPN_KEYOU}\"/" ~/openvpn-ca/vars
+    sed -i -e "s/export KEY_NAME.*/export KEY_NAME=\"${OPENVPN_KEYNAME}\"/" ~/openvpn-ca/vars
 
-### Adjust TLS configuration
-sed -i -e "s/\;tls-auth ta.key 0.*/tls-auth ta.key 0/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
-sed -i -e "/tls-auth ta.key 0/a key-direction 0" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    ## Generate server certificates
+    cd ~/openvpn-ca
+    source vars
+    ./clean-all
+    ./build-ca --batch
+    ./build-key-server --batch ${OPENVPN_KEYNAME}
+    ./build-dh
+    openvpn --genkey --secret keys/ta.key
 
-### Enable AES-128-CBC chipers
-sed -i -e "s/\;cipher AES-128-CBC.*/cipher AES-128-CBC/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
-sed -i -e "/cipher AES-128-CBC/a auth SHA256" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    ## Generate client certificates
+    ./build-key --batch clients
 
-### Set user and group
-sed -i -e "s/\;user nobody.*/user nobody/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
-sed -i -e "s/\;group nogroup.*/group nogroup/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    ## Generate OpenVPN configuration
+    cp ~/openvpn-ca/keys/ca.crt ~/openvpn-ca/keys/ca.key ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.crt \
+        ~/openvpn-ca/keys/${OPENVPN_KEYNAME}.key ~/openvpn-ca/keys/ta.key ~/openvpn-ca/keys/dh2048.pem /etc/openvpn
+    gunzip -c /usr/share/doc/openvpn/examples/sample-config-files/server.conf.gz | tee /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-### TODO(xmudrii): find way to generate new cert for every client
-### Enable duplicate certificates
-sed -i -e "s/\;duplicate-cn.*/duplicate-cn/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    ### Adjust TLS configuration
+    sed -i -e "s/\;tls-auth ta.key 0.*/tls-auth ta.key 0/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "/tls-auth ta.key 0/a key-direction 0" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-## Enable IP forwarding
-sed -i -e "s/\#net.ipv4.ip_forward.*/net.ipv4.ip_forward=1/" /etc/sysctl.conf
+    ### Enable AES-128-CBC chipers
+    sed -i -e "s/\;cipher AES-128-CBC.*/cipher AES-128-CBC/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "/cipher AES-128-CBC/a auth SHA256" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-systemctl start openvpn@${OPENVPN_KEYNAME}
-systemctl enable openvpn@${OPENVPN_KEYNAME}
+    ### Set user and group
+    sed -i -e "s/\;user nobody.*/user nobody/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
+    sed -i -e "s/\;group nogroup.*/group nogroup/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-## Generate client configuration
+    ### TODO(xmudrii): find way to generate new cert for every client
+    ### Enable duplicate certificates
+    sed -i -e "s/\;duplicate-cn.*/duplicate-cn/" /etc/openvpn/${OPENVPN_KEYNAME}.conf
 
-### Create the directory structure and secure it
-mkdir -p ~/client-configs/files
-chmod 700 ~/client-configs/files
+    ## Enable IP forwarding
+    sed -i -e "s/\#net.ipv4.ip_forward.*/net.ipv4.ip_forward=1/" /etc/sysctl.conf
 
-### Generate config from examples
-cp /usr/share/doc/openvpn/examples/sample-config-files/client.conf ~/client-configs/base.conf
+    systemctl start openvpn@${OPENVPN_KEYNAME}
+    systemctl enable openvpn@${OPENVPN_KEYNAME}
 
-### Add remote IP address
-sed -i -e "s/remote my-server-1 1194/remote ${PRIVATE_IP} 1194/" ~/client-configs/base.conf
+    ## Generate client configuration
 
-### Set nobody:nogroup to run OpenVPN
-sed -i -e "s/\;user nobody.*/user nobody/" ~/client-configs/base.conf
-sed -i -e "s/\;group nogroup.*/group nogroup/" ~/client-configs/base.conf
+    ### Create the directory structure and secure it
+    mkdir -p ~/client-configs/files
+    chmod 700 ~/client-configs/files
 
-### Make it not use default certificate
-sed -i -e "s/ca ca.crt/\#ca ca.crt/" ~/client-configs/base.conf
-sed -i -e "s/cert client.crt/\#cert client.crt/" ~/client-configs/base.conf
-sed -i -e "s/key client.key/\#key client.key/" ~/client-configs/base.conf
+    ### Generate config from examples
+    cp /usr/share/doc/openvpn/examples/sample-config-files/client.conf ~/client-configs/base.conf
 
-### Configure chipers
-sed -i -e "s/\;cipher x.*/cipher AES-128-CBC/" ~/client-configs/base.conf
-sed -i -e "/cipher AES-128-CBC/a auth SHA256" ~/client-configs/base.conf
+    ### Add remote IP address
+    sed -i -e "s/remote my-server-1 1194/remote ${PRIVATE_IP} 1194/" ~/client-configs/base.conf
 
-### Additional settings
-echo "key-direction 1" >> ~/client-configs/base.conf
-echo "script-security 2" >> ~/client-configs/base.conf
-echo "up /etc/openvpn/update-resolv-conf" >> ~/client-configs/base.conf
-echo "down /etc/openvpn/update-resolv-conf" >> ~/client-configs/base.conf
+    ### Set nobody:nogroup to run OpenVPN
+    sed -i -e "s/\;user nobody.*/user nobody/" ~/client-configs/base.conf
+    sed -i -e "s/\;group nogroup.*/group nogroup/" ~/client-configs/base.conf
 
-## Generate keys
-KEY_DIR=~/openvpn-ca/keys
-OUTPUT_DIR=/tmp
-BASE_CONFIG=~/client-configs/base.conf
+    ### Make it not use default certificate
+    sed -i -e "s/ca ca.crt/\#ca ca.crt/" ~/client-configs/base.conf
+    sed -i -e "s/cert client.crt/\#cert client.crt/" ~/client-configs/base.conf
+    sed -i -e "s/key client.key/\#key client.key/" ~/client-configs/base.conf
 
-cat ${BASE_CONFIG} \
-    <(echo -e '<ca>') \
-    ${KEY_DIR}/ca.crt \
-    <(echo -e '</ca>\n<cert>') \
-    ${KEY_DIR}/clients.crt \
-    <(echo -e '</cert>\n<key>') \
-    ${KEY_DIR}/clients.key \
-    <(echo -e '</key>\n<tls-auth>') \
-    ${KEY_DIR}/ta.key \
-    <(echo -e '</tls-auth>') \
-    > ${OUTPUT_DIR}/clients.conf
+    ### Configure chipers
+    sed -i -e "s/\;cipher x.*/cipher AES-128-CBC/" ~/client-configs/base.conf
+    sed -i -e "/cipher AES-128-CBC/a auth SHA256" ~/client-configs/base.conf
 
+    ### Additional settings
+    echo "key-direction 1" >> ~/client-configs/base.conf
+    echo "script-security 2" >> ~/client-configs/base.conf
+    echo "up /etc/openvpn/update-resolv-conf" >> ~/client-configs/base.conf
+    echo "down /etc/openvpn/update-resolv-conf" >> ~/client-configs/base.conf
+
+    ## Generate keys
+    KEY_DIR=~/openvpn-ca/keys
+    OUTPUT_DIR=/tmp
+    BASE_CONFIG=~/client-configs/base.conf
+
+    cat ${BASE_CONFIG} \
+        <(echo -e '<ca>') \
+        ${KEY_DIR}/ca.crt \
+        <(echo -e '</ca>\n<cert>') \
+        ${KEY_DIR}/clients.crt \
+        <(echo -e '</cert>\n<key>') \
+        ${KEY_DIR}/clients.key \
+        <(echo -e '</key>\n<tls-auth>') \
+        ${KEY_DIR}/ta.key \
+        <(echo -e '</tls-auth>') \
+        > ${OUTPUT_DIR}/clients.conf
+fi

--- a/bootstrap/vpn/openvpnNode.sh
+++ b/bootstrap/vpn/openvpnNode.sh
@@ -4,17 +4,26 @@
 # and the shell script real work. If you need conditional logic, write it in bash or make another shell script.
 # ------------------------------------------------------------------------------------------------------------------------
 
-PRIVATE_IP=$(curl http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
-
-# OpenVPN
-
-apt-get update
-apt-get install -y openvpn
+apt-get update -y
 apt-get install -y jq
 
-OPENVPN_CONF=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDCONF')
+VPN=$(cat /etc/kubicorn/cluster.json | jq -r '.components.vpn')
 
-echo -e ${OPENVPN_CONF} > /etc/openvpn/clients.conf
+if [ -z $VPN ]; then
+    sleep 7
+    export VPN=$(cat /etc/kubicorn/cluster.json | jq -r '.components.vpn')
+fi
 
-systemctl start openvpn@clients
-systemctl enable openvpn@clients
+if $VPN; then
+    PRIVATE_IP=$(curl http://169.254.169.254/metadata/v1/interfaces/private/0/ipv4/address)
+
+    # OpenVPN
+    apt-get install -y openvpn
+
+    OPENVPN_CONF=$(cat /etc/kubicorn/cluster.json | jq -r '.values.itemMap.INJECTEDCONF')
+
+    echo -e ${OPENVPN_CONF} > /etc/openvpn/clients.conf
+
+    systemctl start openvpn@clients
+    systemctl enable openvpn@clients
+fi

--- a/cutil/defaults/defaults.go
+++ b/cutil/defaults/defaults.go
@@ -34,6 +34,7 @@ func NewClusterDefaults(base *cluster.Cluster) *cluster.Cluster {
 		KubernetesAPI: base.KubernetesAPI,
 		ServerPools:   base.ServerPools,
 		Project:       base.Project,
+		Components:    base.Components,
 	}
 	return new
 }

--- a/cutil/parser/fileresource.go
+++ b/cutil/parser/fileresource.go
@@ -16,6 +16,7 @@ package fileresource
 
 import (
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/kris-nova/kubicorn/cutil/logger"
@@ -24,9 +25,11 @@ import (
 // ReadFromResource reads a file from different sources
 // at the moment suppoted resources are http, http, local file system(POSIX)
 func ReadFromResource(r string) (string, error) {
+	env := os.Getenv("KUBICORN_ENVIRONMENT")
+
 	switch {
 
-	case strings.HasPrefix(strings.ToLower(r), "bootstrap/"):
+	case strings.HasPrefix(strings.ToLower(r), "bootstrap/") && env != "LOCAL":
 
 		// If we start with bootstrap/ we know this is a resource we should pull from github.com
 		// So here we build the GitHub URL and send the request

--- a/docs/_documentation/envar.md
+++ b/docs/_documentation/envar.md
@@ -15,6 +15,7 @@ KUBICORN_NAME | string | The name of the cluster to use
 KUBICORN_PROFILE | string | The profile name to create new clusters APIs with
 KUBICORN_SET | string | Set custom property for the cluster
 KUBICORN_TRUECOLOR | bool | Always run `kubicorn` with lolgopher truecolor
+KUBICORN_ENVIRONMENT | string | If it's set to `LOCAL`, `kubicorn` will use bootstrap local bootstrap scripts instead of remote ones. 
 KUBICORN_FORCE_DELETE_KEY | bool | Force delete key for AWS or Packet
 KUBICORN_FORCE_DISABLE_SSH_AGENT | bool | Force SCP and SSH to never use SSH agent
 --- | --- | ---

--- a/profiles/digitalocean/centos_7.go
+++ b/profiles/digitalocean/centos_7.go
@@ -39,6 +39,9 @@ func NewCentosCluster(name string) *cluster.Cluster {
 				"INJECTEDTOKEN": kubeadm.GetRandomToken(),
 			},
 		},
+		Components: &cluster.Components{
+			ComponentVPN: false,
+		},
 		ServerPools: []*cluster.ServerPool{
 			{
 				Type:     cluster.ServerPoolTypeMaster,
@@ -50,16 +53,89 @@ func NewCentosCluster(name string) *cluster.Cluster {
 					"bootstrap/vpn/openvpnMaster-centos.sh",
 					"bootstrap/digitalocean_k8s_centos_7_master.sh",
 				},
+				Firewalls: []*cluster.Firewall{
+					{
+						Name: fmt.Sprintf("%s-master", name),
+						IngressRules: []*cluster.IngressRule{
+							{
+								IngressToPort:   "22",
+								IngressSource:   "0.0.0.0/0",
+								IngressProtocol: "tcp",
+							},
+							{
+								IngressToPort:   "443",
+								IngressSource:   "0.0.0.0/0",
+								IngressProtocol: "tcp",
+							},
+							{
+								IngressToPort:   "1194",
+								IngressSource:   "0.0.0.0/0",
+								IngressProtocol: "udp",
+							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-node", name),
+								IngressProtocol: "tcp",
+							},
+						},
+						EgressRules: []*cluster.EgressRule{
+							{
+								EgressToPort:      "all", // By default all egress from VM
+								EgressDestination: "0.0.0.0/0",
+								EgressProtocol:    "tcp",
+							},
+							{
+								EgressToPort:      "all", // By default all egress from VM
+								EgressDestination: "0.0.0.0/0",
+								EgressProtocol:    "udp",
+							},
+						},
+					},
+				},
 			},
 			{
 				Type:     cluster.ServerPoolTypeNode,
 				Name:     fmt.Sprintf("%s-node", name),
-				MaxCount: 1,
+				MaxCount: 2,
 				Image:    "centos-7-x64",
 				Size:     "s-1vcpu-2gb",
 				BootstrapScripts: []string{
 					"bootstrap/vpn/openvpnNode-centos.sh",
 					"bootstrap/digitalocean_k8s_centos_7_node.sh",
+				},
+				Firewalls: []*cluster.Firewall{
+					{
+						Name: fmt.Sprintf("%s-node", name),
+						IngressRules: []*cluster.IngressRule{
+							{
+								IngressToPort:   "22",
+								IngressSource:   "0.0.0.0/0",
+								IngressProtocol: "tcp",
+							},
+							{
+								IngressToPort:   "1194",
+								IngressSource:   "0.0.0.0/0",
+								IngressProtocol: "udp",
+							},
+							{
+								IngressToPort:   "all",
+								IngressSource:   fmt.Sprintf("%s-master", name),
+								IngressProtocol: "tcp",
+							},
+						},
+						EgressRules: []*cluster.EgressRule{
+							{
+								EgressToPort:      "all", // By default all egress from VM
+								EgressDestination: "0.0.0.0/0",
+								EgressProtocol:    "tcp",
+							},
+							{
+								EgressToPort:      "all", // By default all egress from VM
+								EgressDestination: "0.0.0.0/0",
+								EgressProtocol:    "udp",
+							},
+						},
+					},
 				},
 			},
 		},

--- a/profiles/digitalocean/ubuntu_16_04.go
+++ b/profiles/digitalocean/ubuntu_16_04.go
@@ -39,6 +39,9 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 				"INJECTEDTOKEN": kubeadm.GetRandomToken(),
 			},
 		},
+		Components: &cluster.Components{
+			ComponentVPN: false,
+		},
 		ServerPools: []*cluster.ServerPool{
 			{
 				Type:     cluster.ServerPoolTypeMaster,


### PR DESCRIPTION
This PR reworks the cluster provisioning process on DigitalOcean. This method provides a great base for further improvements, such as implementing DO CCM (#276), Dashboard or Heapster.

### Changelog

* [ADD] Added **Components** API structure for defining optional cluster components.
* [ADD] Added and documented the `KUBICORN_ENVIRONMENT` variable, used to instruct `kubicorn` to use local bootstrap scripts. Closes #523.
* [ADD] Create a Cloud Firewall while provisioning the CentOS clusters.
* [FIX] Wait before populating the state if `godo` returns empty string instead of an IP address.
* [FIX] Fix networking issues by adding the appropriate flag to the `kubelet` service.
* [CHANGE] Switch to WeaveNet for CNI.
* [CHANGE] VPN is disabled by default now. In order to enable it, you need to change the `.components.vpn` to `true` in the profile or state. We're already protected by the firewall, so VPN is not necessary. Also, DigitalOcean will lock down Private Networking to Droplets on the same account soon, ensuring clusters are even safer.
* [CHANGE] Use a configuration file for `kubeadm` instead of flags.

All integration tests are passing with this setup (tested using heptio/sonobuoy).

Credits to @alexellis for his [Kubernetes blog post](https://blog.alexellis.io/your-instant-kubernetes-cluster/), covering how to install WeaveNet on the DigitalOcean cluster. It helped me a lot to finally get Weave working on DO.