### PR TITLE
Fix a few documentation links to GitHub :)

### DIFF
--- a/docs/_documentation/cloud-providers.md
+++ b/docs/_documentation/cloud-providers.md
@@ -10,13 +10,13 @@ doctype: general
 In order to add a new cloud provider, you need to implement several key functions and interfaces:
 
 0. Create a name for this cloud provider as a string, e.g. `"mycloud"` and keep it handy.
-1. Create a `const` representing the name of the cloud in [cluster.go](https://github.com/kris-nova/kubicorn/apis/cluster/cluster.go#L21), with the `const` name being `Cloud<name>` and the value being the name from the first step.
-2. Create a subdirectory in this [cloud](https://github.com/kris-nova/kubicorn/cloud) directory named for the provider providing a cloud implementation. The directory name should be the name of the provider from the first step. A cloud implementation is all of the constants, interfaces and functions necessary to execute commands against a cloud provider.
-3. Create a subdirectory in the [profiles directory](https://github.com/kris-nova/kubicorn/profiles) named for the provider. The directory name should be the same as the name of the provider from the first step.
-4. Create one or more profiles for the provider in the [profiles directory](https://github.com/kris-nova/kubicorn/profiles) for the provider. A profile contains all of the necessary information to create a specific implementation in a given cloud provider, e.g. instance size, ssh key, etc.
-5. Add the implemented profiles as profile options to `profileMapIndexed` in [create.go](https://github.com/kris-nova/kubicorn/cmd/create.go). Be sure to `import` the necessary package from `profiles/`
-6. Add the provider as a `known.Cloud` to [reconciler.go](https://github.com/kris-nova/kubicorn/cutil/reconciler.go)
-7. Add any bootstrap scripts required in [bootstrap/](https://github.com/kris-nova/kubicorn/bootstrap/). As a general rule, the name of the script should be `<provider>_k8s_<profile>_master.sh` or `<provider>_k8s_<profile>_node.sh`
+1. Create a `const` representing the name of the cloud in [cluster.go](https://github.com/kris-nova/kubicorn/blob/master/apis/cluster/cluster.go#L21), with the `const` name being `Cloud<name>` and the value being the name from the first step.
+2. Create a subdirectory in this [cloud](https://github.com/kris-nova/kubicorn/tree/master/cloud) directory named for the provider providing a cloud implementation. The directory name should be the name of the provider from the first step. A cloud implementation is all of the constants, interfaces and functions necessary to execute commands against a cloud provider.
+3. Create a subdirectory in the [profiles directory](https://github.com/kris-nova/kubicorn/tree/master/profiles) named for the provider. The directory name should be the same as the name of the provider from the first step.
+4. Create one or more profiles for the provider in the [profiles directory](https://github.com/kris-nova/kubicorn/tree/master/profiles) for the provider. A profile contains all of the necessary information to create a specific implementation in a given cloud provider, e.g. instance size, ssh key, etc.
+5. Add the implemented profiles as profile options to `profileMapIndexed` in [create.go](https://github.com/kris-nova/kubicorn/blob/master/cmd/create.go). Be sure to `import` the necessary package from `profiles/`
+6. Add the provider as a `known.Cloud` to [reconciler.go](https://github.com/kris-nova/kubicorn/blob/master/cutil/reconciler.go)
+7. Add any bootstrap scripts required in [bootstrap/](https://github.com/kris-nova/kubicorn/tree/master/bootstrap/). As a general rule, the name of the script should be `<provider>_k8s_<profile>_master.sh` or `<provider>_k8s_<profile>_node.sh`
 
 ### Profile
 A profile is expected to return a single function, the "profile function". You can name that function anything you want. In `create.go`, you will save that function as `profileFunc` and then call it.
@@ -43,12 +43,12 @@ Notice that it doesn't matter _what_ the function was named. It could have been 
 
 If you have multiple profiles - perhaps different VM sizes or different OSes - you simply use a different profile function and save it under a different key un the `profileMapIndexed` map.
 
-The profile function itself is expected to return `*cluster.Cluster` from the package [apis/cluster](https://github.com/kris-nova/kubicorn/apis/cluster). This is a struct with all of the information necessary to create the resources for the cluster.
+The profile function itself is expected to return `*cluster.Cluster` from the package [apis/cluster](https://github.com/kris-nova/kubicorn/tree/master/apis/cluster). This is a struct with all of the information necessary to create the resources for the cluster.
 
 ### Cloud Provider Implementation
 The cloud provider profile is the mapping between the generic cloud API used to perform functions on cloud providers, and the specific API calls required for your cloud provider.
 
-The cloud provider implementation is expect to provide a function that returns an implementation of [Model](https://github.com/kris-nova/kubicorn/cloud/interface.go#L39). This typically is done using a function with the following signature:
+The cloud provider implementation is expect to provide a function that returns an implementation of [Model](https://github.com/kris-nova/kubicorn/blob/master/cloud/interface.go#L39). This typically is done using a function with the following signature:
 
 ```go
 GetModel(known *cluster.Cluster) cloud.Model
@@ -58,7 +58,7 @@ The function should use the `known` parameter to provide profile-specific inform
 
 You can name the function anything you want.
 
-This model factory should be called from within the appropriate provider-specific block in [reconciler.go](https://github.com/kris-nova/kubicorn/cutil/reconciler.go). the block is expected to do the following:
+This model factory should be called from within the appropriate provider-specific block in [reconciler.go](https://github.com/kris-nova/kubicorn/blob/master/cutil/reconciler.go). the block is expected to do the following:
 
 1. Initialize any APIs or SDKs necessary.
 2. Call `cloud.NewAtomicReconciler(known, ModelFunc(known))` , where `ModelFunc` is the model function for your cloud provider implementation.


### PR DESCRIPTION
Links into GitHub refs (for directories & code) were failing 404 due to missing some path bits.