### PR TITLE
Update AWS Profile's Ubuntu AMIs

### DIFF
--- a/profiles/amazon/ubuntu_16_04.go
+++ b/profiles/amazon/ubuntu_16_04.go
@@ -51,7 +51,7 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 				Name:     fmt.Sprintf("%s.master", name),
 				MaxCount: 1,
 				MinCount: 1,
-				Image:    "ami-835b4efa",
+				Image:    "ami-79873901",
 				Size:     "t2.xlarge",
 				BootstrapScripts: []string{
 					"bootstrap/amazon_k8s_ubuntu_16.04_master.sh",
@@ -128,7 +128,7 @@ func NewUbuntuCluster(name string) *cluster.Cluster {
 				Name:     fmt.Sprintf("%s.node", name),
 				MaxCount: 1,
 				MinCount: 1,
-				Image:    "ami-835b4efa",
+				Image:    "ami-79873901",
 				Size:     "t2.medium",
 				BootstrapScripts: []string{
 					"bootstrap/amazon_k8s_ubuntu_16.04_node.sh",


### PR DESCRIPTION
Update the AMI versions to a more recent version that mitigates the recent exploits (spectre, meltdown).

The AMI specified is in the us-west-2 region, with kernel version > 4.4.X, which contains the updates to mitigate spectre variant 1, spectre variant 2 (but requires updated firmware/microcode), and meltdown as per https://wiki.ubuntu.com/SecurityTeam/KnowledgeBase/SpectreAndMeltdown

AMI details from AWS Community AMIs: `ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180126 - ami-79873901`