### PR TITLE
Use an existing instance profile if found

### DIFF
--- a/cloud/amazon/public/resources/instanceprofile.go
+++ b/cloud/amazon/public/resources/instanceprofile.go
@@ -176,6 +176,7 @@ func (r *InstanceProfile) Apply(actual, expected cloud.Resource, immutable *clus
 	//TODO fill in instanceprofile attributes
 
 	// Create InstanceProfile
+	var nameStr, idStr string
 	profileinput := &iam.CreateInstanceProfileInput{
 		InstanceProfileName: &expected.(*InstanceProfile).Name,
 		Path:                S("/"),
@@ -185,10 +186,24 @@ func (r *InstanceProfile) Apply(actual, expected cloud.Resource, immutable *clus
 		logger.Debug("CreateInstanceProfile error: %v", err)
 		if err.(awserr.Error).Code() != iam.ErrCodeEntityAlreadyExistsException {
 			return nil, nil, err
+		} else {
+			logger.Debug("InstanceProfile found, using existing.")
+			profileinput := &iam.GetInstanceProfileInput{
+				InstanceProfileName: &expected.(*InstanceProfile).Name,
+			}
+			outInstanceProfile, err := Sdk.IAM.GetInstanceProfile(profileinput)
+			if err != nil {
+				return nil, nil, err
+			}
+			nameStr = *outInstanceProfile.InstanceProfile.InstanceProfileName
+			idStr = *outInstanceProfile.InstanceProfile.InstanceProfileId
 		}
+	} else {
+		nameStr = *outInstanceProfile.InstanceProfile.InstanceProfileName
+		idStr = *outInstanceProfile.InstanceProfile.InstanceProfileId
 	}
-	newResource.Name = *outInstanceProfile.InstanceProfile.InstanceProfileName
-	newResource.Identifier = *outInstanceProfile.InstanceProfile.InstanceProfileName
+	newResource.Name = nameStr
+	newResource.Identifier = idStr
 	logger.Info("InstanceProfile created: %s", newResource.Name)
 	// Create role
 	assumeRolePolicy := `{


### PR DESCRIPTION
Since we can detect whether or not an instance profile exists via error
types, attempt to re-use an existing instance profile before returning
an error.

The name and id have to be extracted seperately since the returned
values for creating an instance profile and getting one are two
different types.

Signed-off-by: Nolan Brubaker <nolan@heptio.com>